### PR TITLE
Poll service to sync to allow multiple component to poll the same resource effictivelly

### DIFF
--- a/app/components/pool/graphs/pool-graphs.component.ts
+++ b/app/components/pool/graphs/pool-graphs.component.ts
@@ -42,6 +42,7 @@ export class PoolGraphsComponent implements OnChanges, OnDestroy {
 
     public runningTaskHistory = new RunningTasksHistoryData();
     public runningNodesHistory = new NodesStateHistoryData([NodeState.running, NodeState.idle]);
+    public maxRunningTasks = 0;
 
     public focusedGraph = AvailableGraph.Heatmap;
     public selectedHistoryLength = new FormControl(HistoryLength.TenMinute);
@@ -77,6 +78,7 @@ export class PoolGraphsComponent implements OnChanges, OnDestroy {
         if (changes.pool) {
             this.data.updateParams({ poolId: this.pool.id });
             this.data.refresh(false);
+            this.maxRunningTasks = this.pool ? this.pool.targetDedicated * this.pool.maxTasksPerNode : 0;
         }
     }
 

--- a/app/components/pool/graphs/pool-graphs.component.ts
+++ b/app/components/pool/graphs/pool-graphs.component.ts
@@ -71,14 +71,6 @@ export class PoolGraphsComponent implements OnChanges, OnDestroy {
             this.runningTaskHistory.setHistorySize(value);
         });
         this._poll = this.data.startPoll(refreshRate);
-
-        setTimeout(() => {
-            const data2 = nodeService.list(this.pool.id, {
-                maxResults: 1000,
-                select: "recentTasks,id,state",
-            });
-            data2.startPoll(2000);
-        }, 12000);
     }
 
     public ngOnChanges(changes) {

--- a/app/components/pool/graphs/pool-graphs.html
+++ b/app/components/pool/graphs/pool-graphs.html
@@ -17,7 +17,7 @@
     </div>
     <div class="preview" (click)="focusGraph(AvailableGraph.RunningTasks)" [class.focused]="focusedGraph === AvailableGraph.RunningTasks">
         <div class="label">Running tasks</div>
-        <bl-history-graph [max]="10" class="small-preview" [history]="runningTaskHistory.history" [interactive]="false" [historySize]="selectedHistoryLength.value">
+        <bl-history-graph [max]="maxRunningTasks" class="small-preview" [history]="runningTaskHistory.history" [interactive]="false" [historySize]="selectedHistoryLength.value">
         </bl-history-graph>
     </div>
     <div class="config">
@@ -38,7 +38,7 @@
         </bl-history-graph>
     </div>
     <div *ngSwitchCase="AvailableGraph.RunningTasks" class="full-display">
-        <bl-history-graph [max]="10" class="full-display" [history]="runningTaskHistory.history" [historySize]="selectedHistoryLength.value">
+        <bl-history-graph [max]="maxRunningTasks" class="full-display" [history]="runningTaskHistory.history" [historySize]="selectedHistoryLength.value">
         </bl-history-graph>
     </div>
 </div>

--- a/app/services/core/data-cache.ts
+++ b/app/services/core/data-cache.ts
@@ -2,6 +2,7 @@ import { Map } from "immutable";
 import { BehaviorSubject, Observable, Subject } from "rxjs";
 
 import { ObjectUtils, SecureUtils } from "app/utils";
+import { PollService } from "./poll-service";
 import { QueryCache } from "./query-cache";
 
 export class DataCacheTracker {
@@ -39,6 +40,7 @@ export class DataCache<T> {
     public deleted: Observable<string>;
 
     public queryCache = new QueryCache();
+    public pollService = new PollService();
 
     private _items = new BehaviorSubject<Map<string, T>>(Map<string, T>({}));
     private _deleted = new Subject<string>();

--- a/app/services/core/index.ts
+++ b/app/services/core/index.ts
@@ -8,3 +8,4 @@ export * from "./rx-list-proxy";
 export * from "./targeted-data-cache";
 export * from "./long-running-action";
 export * from "./query-cache";
+export * from "./poll-service";

--- a/app/services/core/poll-service.ts
+++ b/app/services/core/poll-service.ts
@@ -1,10 +1,8 @@
 import { ObjectUtils, SecureUtils } from "app/utils";
 
-
 export class PollService {
     private _pollTrackers: StringMap<StringMap<PollTracker>> = {};
     private _activePoolTrackers: StringMap<PollTracker> = {};
-
 
     public startPoll(key: string, interval: number, callback: Function): PollObservable {
         const tracker = new PollTracker(interval, callback);

--- a/app/services/core/poll-service.ts
+++ b/app/services/core/poll-service.ts
@@ -1,0 +1,124 @@
+import { ObjectUtils, SecureUtils } from "app/utils";
+
+
+export class PollService {
+    private _pollTrackers: StringMap<StringMap<PollTracker>> = {};
+    private _activePoolTrackers: StringMap<PollTracker> = {};
+
+
+    public startPoll(key: string, interval: number, callback: Function): PollObservable {
+        const tracker = new PollTracker(interval, callback);
+        this._addTracker(key, tracker);
+        return new PollObservable(this, key, tracker.id);
+    }
+
+    public stopPoll(key: string, id: string) {
+        this._stopPoll(key, id);
+    }
+
+    public updateKeyFor(currentKey: string, id: string, newKey: string) {
+        const tracker = this._stopPoll(currentKey, id);
+        if (!tracker) {
+            return;
+        }
+        this._addTracker(newKey, tracker);
+    }
+
+    private _updateActivePoll(key: string) {
+        const trackers = this._pollTrackers[key];
+        if (Object.keys(trackers).length === 0) {
+            return;
+        }
+        const smallest = ObjectUtils.values(trackers).reduce((a, b) => a.interval < b.interval ? a : b);
+        this._activePoolTrackers[key] = smallest;
+    }
+
+    private _clearActivePoll(key: string) {
+        if (!(key in this._activePoolTrackers)) {
+            return;
+        }
+
+        this._activePoolTrackers[key].stop();
+        delete this._activePoolTrackers[key];
+    }
+
+    private _startActivePoll(key: string) {
+        if (!(key in this._activePoolTrackers)) {
+            return;
+        }
+        this._activePoolTrackers[key].start();
+    }
+
+    private _getTracker(key: string, id: string) {
+        if (!(key in this._pollTrackers && id in this._pollTrackers[key])) {
+            return null;
+        }
+        return this._pollTrackers[key][id];
+    }
+
+    private _addTracker(key: string, tracker: PollTracker) {
+        if (!(key in this._pollTrackers)) {
+            this._pollTrackers[key] = {};
+        }
+        this._pollTrackers[key][tracker.id] = tracker;
+        this._clearActivePoll(key);
+        this._updateActivePoll(key);
+        this._startActivePoll(key);
+    }
+
+    private _stopPoll(key: string, id: string) {
+        const tracker = this._getTracker(key, id);
+        if (!tracker) {
+            return;
+        }
+        delete this._pollTrackers[key][id];
+        if (tracker.running) {
+            this._clearActivePoll(key);
+            this._updateActivePoll(key);
+            this._startActivePoll(key);
+        }
+        return tracker;
+    }
+}
+
+class PollTracker {
+    public id: string;
+    private _currentInterval: any;
+
+    constructor(public interval: number, public callback: Function) {
+        this.id = SecureUtils.uuid();
+    }
+
+    public get running(): boolean {
+        return Boolean(this._currentInterval);
+    }
+
+    public start() {
+        this.stop();
+        this._currentInterval = setInterval(() => {
+            this.callback();
+        }, this.interval);
+    }
+
+    public stop() {
+        if (this._currentInterval) {
+            clearInterval(this._currentInterval);
+        }
+    }
+}
+
+export class PollObservable {
+    constructor(private service: PollService, private key: string, private id: string) { }
+
+    public destroy() {
+        this.service.stopPoll(this.key, this.id);
+    }
+
+    public updateKey(newKey: string) {
+        if (newKey === this.key) {
+            return;
+        }
+        this.service.updateKeyFor(this.key, this.id, newKey);
+        this.key = newKey;
+    }
+}

--- a/app/services/core/rx-entity-proxy.ts
+++ b/app/services/core/rx-entity-proxy.ts
@@ -60,6 +60,10 @@ export abstract class RxEntityProxy<TParams, TEntity> extends RxProxyBase<TParam
         return this.fetch();
     }
 
+    protected pollRefresh() {
+        return this.refresh();
+    }
+
     protected abstract getData(): Observable<any>;
 }
 

--- a/app/services/core/rx-list-proxy.ts
+++ b/app/services/core/rx-list-proxy.ts
@@ -142,6 +142,10 @@ export abstract class RxListProxy<TParams, TEntity> extends RxProxyBase<TParams,
         return this.fetchNext(true);
     }
 
+    protected pollRefresh() {
+        return this.refresh(false);
+    }
+
     // Method to implement in the child class
     protected abstract handleChanges(params: TParams, options: {});
     protected abstract fetchNextItems(): Observable<any>;

--- a/app/services/core/rx-proxy-base.ts
+++ b/app/services/core/rx-proxy-base.ts
@@ -143,12 +143,6 @@ export abstract class RxProxyBase<TParams, TOptions extends OptionsBase, TEntity
         return this._pollObservable;
     }
 
-    private _key() {
-        const paramsKey = ObjectUtils.serialize(this._params);
-        const optionsKey = ObjectUtils.serialize(this._options);
-        return `${paramsKey}|${optionsKey}`;
-    }
-
     protected set cache(cache: DataCache<TEntity>) {
         this._cache = cache;
         this._clearDeleteSub();
@@ -231,4 +225,10 @@ export abstract class RxProxyBase<TParams, TOptions extends OptionsBase, TEntity
     }
 
     protected abstract pollRefresh(): Observable<any>;
+
+    private _key() {
+        const paramsKey = ObjectUtils.serialize(this._params);
+        const optionsKey = ObjectUtils.serialize(this._options);
+        return `${paramsKey}|${optionsKey}`;
+    }
 }

--- a/app/services/core/targeted-data-cache.ts
+++ b/app/services/core/targeted-data-cache.ts
@@ -1,4 +1,5 @@
 import { DataCache } from "./data-cache";
+import { PollService } from "./poll-service";
 
 export interface TargetedDataCacheOptions<TParams> {
     /**
@@ -14,6 +15,8 @@ const defaultOptions: TargetedDataCacheOptions<any> = {
 export class TargetedDataCache<TParams, TEntity> {
     private _caches = new Map<string, DataCache<TEntity>>();
     private _options: TargetedDataCacheOptions<TParams>;
+
+    private _pollService = new PollService();
 
     constructor(options: TargetedDataCacheOptions<TParams> = {}, private _uniqueField = "id") {
         this._options = Object.assign({}, defaultOptions, options);
@@ -31,6 +34,7 @@ export class TargetedDataCache<TParams, TEntity> {
         let cache = this._caches.get(key);
         if (!cache) {
             cache = new DataCache<TEntity>(this._uniqueField);
+            cache.pollService = this._pollService;
             this._caches.set(key, cache);
         }
         return cache;

--- a/app/utils/object.ts
+++ b/app/utils/object.ts
@@ -48,6 +48,15 @@ export class ObjectUtils {
         }
         return out;
     }
+
+    /**
+     * Serialize a simple object to a form that is supposed to be always the same.
+     */
+    public static serialize(obj: { [key: string]: any }) {
+        return Object.keys(obj)
+            .sort()
+            .map(x => `${x}:${obj[x]}`).join(",");
+    }
 }
 
 /**

--- a/definitions/index.d.ts
+++ b/definitions/index.d.ts
@@ -24,3 +24,6 @@ declare module "mousetrap" {
     function trigger(key: string);
     function reset();
 }
+
+
+type StringMap<V> = { [key: string]: V };

--- a/test/app/services/core/data-cache.spec.ts
+++ b/test/app/services/core/data-cache.spec.ts
@@ -1,7 +1,6 @@
 import { DataCache } from "app/services/core/data-cache";
 import { Map, Record } from "immutable";
 
-// tslint:disable:variable-name
 const FakeRecord = Record({
     id: null,
     state: null,

--- a/test/app/services/core/poll-service.spec.ts
+++ b/test/app/services/core/poll-service.spec.ts
@@ -1,0 +1,106 @@
+import { fakeAsync, tick } from "@angular/core/testing";
+
+import { PollService, PollObservable } from "app/services/core";
+
+fdescribe("PollService", () => {
+    let service: PollService;
+    let poll1: PollObservable;
+    let poll1Spy: jasmine.Spy;
+    let poll2: PollObservable;
+    let poll2Spy: jasmine.Spy;
+
+    beforeEach(() => {
+        service = new PollService();
+        poll1Spy = jasmine.createSpy("Poll-1");
+        poll2Spy = jasmine.createSpy("Poll-2");
+    });
+
+    it("should start a poll", fakeAsync(() => {
+        poll1 = service.startPoll("key-1", 1000, poll1Spy);
+
+        expect(poll1Spy).toHaveBeenCalledTimes(0);
+        tick(1000);
+        expect(poll1Spy).toHaveBeenCalledTimes(1);
+        tick(2000);
+        expect(poll1Spy).toHaveBeenCalledTimes(3);
+        poll1.destroy();
+        tick(2000);
+        expect(poll1Spy).toHaveBeenCalledTimes(3);
+    }));
+
+    it("starting a poll with a long timer should not active it", fakeAsync(() => {
+        poll1 = service.startPoll("key-1", 1000, poll1Spy);
+
+        poll2 = service.startPoll("key-1", 2000, poll2Spy);
+        tick(4000);
+        expect(poll2Spy).not.toHaveBeenCalled();
+        expect(poll1Spy).toHaveBeenCalledTimes(4);
+
+        poll1.destroy();
+        tick(4000);
+        expect(poll2Spy).toHaveBeenCalledTimes(2);
+        expect(poll1Spy).toHaveBeenCalledTimes(4);
+        poll2.destroy();
+    }));
+
+    it("starting a poll with a smaller timer should active it", fakeAsync(() => {
+        poll1 = service.startPoll("key-1", 1000, poll1Spy);
+
+        poll2 = service.startPoll("key-1", 500, poll2Spy);
+        tick(4000);
+        expect(poll2Spy).toHaveBeenCalledTimes(8);
+        expect(poll1Spy).not.toHaveBeenCalled();
+
+        poll1.destroy();
+        tick(4000);
+        expect(poll2Spy).toHaveBeenCalledTimes(16);
+        expect(poll1Spy).not.toHaveBeenCalled();
+        poll2.destroy();
+    }));
+
+    it("starting a poll with a different key should also start it", fakeAsync(() => {
+        poll1 = service.startPoll("key-1", 1000, poll1Spy);
+
+        poll2 = service.startPoll("key-2", 2000, poll2Spy);
+        tick(4000);
+        expect(poll1Spy).toHaveBeenCalledTimes(4);
+        expect(poll2Spy).toHaveBeenCalledTimes(2);
+
+        poll1.destroy();
+        tick(4000);
+        expect(poll1Spy).toHaveBeenCalledTimes(4);
+        expect(poll2Spy).toHaveBeenCalledTimes(4);
+        poll2.destroy();
+    }));
+
+    it("update key of a poll and replace with better timer", fakeAsync(() => {
+        poll1 = service.startPoll("key-1", 1000, poll1Spy);
+
+        poll2 = service.startPoll("key-2", 500, poll2Spy);
+        tick(2000);
+        expect(poll1Spy).toHaveBeenCalledTimes(2);
+        expect(poll2Spy).toHaveBeenCalledTimes(4);
+        poll2.updateKey("key-1");
+        tick(2000);
+        expect(poll1Spy).toHaveBeenCalledTimes(2); // SHould not call first one anymore
+        expect(poll2Spy).toHaveBeenCalledTimes(8);
+        poll1.destroy();
+        poll2.destroy();
+    }));
+
+    it("update key of a poll should free other larger timer", fakeAsync(() => {
+        poll1 = service.startPoll("key-1", 1000, poll1Spy);
+
+        poll2 = service.startPoll("key-1", 500, poll2Spy);
+        tick(2000);
+        expect(poll1Spy).toHaveBeenCalledTimes(0);
+        expect(poll2Spy).toHaveBeenCalledTimes(4);
+        poll2.updateKey("key-2");
+        tick(2000);
+        expect(poll1Spy).toHaveBeenCalledTimes(2); // SHould not call first one anymore
+        expect(poll2Spy).toHaveBeenCalledTimes(8);
+        poll1.destroy();
+        poll2.destroy();
+    }));
+
+});

--- a/test/app/services/core/poll-service.spec.ts
+++ b/test/app/services/core/poll-service.spec.ts
@@ -1,8 +1,8 @@
 import { fakeAsync, tick } from "@angular/core/testing";
 
-import { PollService, PollObservable } from "app/services/core";
+import { PollObservable, PollService } from "app/services/core";
 
-fdescribe("PollService", () => {
+describe("PollService", () => {
     let service: PollService;
     let poll1: PollObservable;
     let poll1Spy: jasmine.Spy;
@@ -102,5 +102,4 @@ fdescribe("PollService", () => {
         poll1.destroy();
         poll2.destroy();
     }));
-
 });

--- a/test/app/utils/object.spec.ts
+++ b/test/app/utils/object.spec.ts
@@ -43,4 +43,12 @@ describe("Object extensions", () => {
         expect(nil(null)).toBe(true);
         expect(nil(undefined)).toBe(true);
     });
+
+    it("serialize object", () => {
+        const s1 = ObjectUtils.serialize({ a: 1, b: 2 });
+        const s2 = ObjectUtils.serialize({ b: 2, a: 1 });
+        const s3 = ObjectUtils.serialize({ b: 3, a: 1 });
+        expect(s1).toEqual(s2);
+        expect(s1).not.toEqual(s3);
+    });
 });


### PR DESCRIPTION
If we have multiple components that would poll same set of resources, then it would be ineficient to have to double every call. This allow a sync between component as it keeps only the smallest timer for each resource.