### PR TITLE
Fix bug with query cache loading items too litle at the time

### DIFF
--- a/app/components/job/action/add/pool-picker.component.ts
+++ b/app/components/job/action/add/pool-picker.component.ts
@@ -5,7 +5,7 @@ import { Observable, Subscription } from "rxjs";
 
 import { Pool } from "app/models";
 import { PoolService, VmSizeService } from "app/services";
-import { RxListProxy } from "app/services/core";
+import { ListOptionsAttributes, RxListProxy } from "app/services/core";
 import { PoolUtils } from "app/utils";
 import { FilterBuilder } from "app/utils/filter-builder";
 
@@ -95,7 +95,7 @@ export class PoolPickerComponent implements ControlValueAccessor, OnInit, OnDest
     }
 
     private _computeOptions(query: string = null) {
-        let options: any = { maxResults: 20 };
+        let options: ListOptionsAttributes = { maxItems: 2 };
         if (query) {
             options.filter = FilterBuilder.prop("id").startswith(query.clearWhitespace()).toOData();
         }

--- a/app/components/job/action/add/pool-picker.component.ts
+++ b/app/components/job/action/add/pool-picker.component.ts
@@ -95,7 +95,7 @@ export class PoolPickerComponent implements ControlValueAccessor, OnInit, OnDest
     }
 
     private _computeOptions(query: string = null) {
-        let options: ListOptionsAttributes = { maxItems: 2 };
+        let options: ListOptionsAttributes = { maxItems: 20 };
         if (query) {
             options.filter = FilterBuilder.prop("id").startswith(query.clearWhitespace()).toOData();
         }

--- a/app/components/job/details/job-progress-status/job-progress-status.component.ts
+++ b/app/components/job/details/job-progress-status/job-progress-status.component.ts
@@ -37,7 +37,7 @@ export class JobProgressStatusComponent implements OnChanges, OnDestroy {
     constructor(private poolService: PoolService, private nodeService: NodeService) {
         this.poolData = poolService.get(null);
         this.data = nodeService.list(null, {
-            maxResults: 1000,
+            pageSize: 1000,
             select: "recentTasks,id,state",
         });
 

--- a/app/components/pool/browse/pool-list.component.ts
+++ b/app/components/pool/browse/pool-list.component.ts
@@ -47,7 +47,7 @@ export class PoolListComponent extends ListOrTableBase implements OnInit, OnDest
         this._filter = filter;
 
         if (filter.isEmpty()) {
-            this.data.setOptions({ pageSize: 5 });
+            this.data.setOptions({});
         } else {
             this.data.setOptions({ filter: filter.toOData() });
         }

--- a/app/components/pool/browse/pool-list.component.ts
+++ b/app/components/pool/browse/pool-list.component.ts
@@ -47,7 +47,7 @@ export class PoolListComponent extends ListOrTableBase implements OnInit, OnDest
         this._filter = filter;
 
         if (filter.isEmpty()) {
-            this.data.setOptions({});
+            this.data.setOptions({ pageSize: 5 });
         } else {
             this.data.setOptions({ filter: filter.toOData() });
         }

--- a/app/components/pool/graphs/pool-graphs.component.ts
+++ b/app/components/pool/graphs/pool-graphs.component.ts
@@ -54,7 +54,7 @@ export class PoolGraphsComponent implements OnChanges, OnDestroy {
 
     constructor(private nodeService: NodeService, private router: Router) {
         this.data = nodeService.list(null, {
-            maxResults: 1000,
+            pageSize: 1000,
             select: "recentTasks,id,state",
         });
         this._nodesSub = this.data.items.subscribe((nodes) => {

--- a/app/components/task/browse/task-list.component.ts
+++ b/app/components/task/browse/task-list.component.ts
@@ -58,7 +58,7 @@ export class TaskListComponent extends SelectableList implements OnInit {
 
     private _filter: Filter;
     private _jobId: string;
-    private _baseOptions = { maxResults: 25 };
+    private _baseOptions = { pageSize: 25 };
     private _onTaskAddedSub: Subscription;
 
     constructor(

--- a/app/services/core/index.ts
+++ b/app/services/core/index.ts
@@ -9,3 +9,4 @@ export * from "./targeted-data-cache";
 export * from "./long-running-action";
 export * from "./query-cache";
 export * from "./poll-service";
+export * from "./list-options";

--- a/app/services/core/list-options.ts
+++ b/app/services/core/list-options.ts
@@ -1,0 +1,84 @@
+import { ObjectUtils } from "app/utils";
+import { OptionsBase } from "./rx-proxy-base";
+
+export interface ListOptionsAttributes extends OptionsBase {
+    /**
+     * Maximum number of items to fetch at the same time
+     * If not provided but maxItems is it will use maxItems value
+     */
+    pageSize?: number;
+
+    /**
+     * Maximum number of items to return from the list proxy(If you only want to show the first 5 items)
+     */
+    maxItems?: number;
+
+    /**
+     *
+     */
+    filter?: string;
+
+    /**
+     * Other options
+     */
+    [key: string]: any;
+}
+
+export class ListOptions {
+    public pageSize: number;
+    public maxItems: number;
+    public filter: string;
+    public select: string;
+
+    public attributes: { [key: string]: any };
+
+    public original: ListOptionsAttributes;
+
+    constructor(attributes: ListOptionsAttributes) {
+        this.pageSize = attributes.pageSize;
+        this.maxItems = attributes.maxItems;
+        this.filter = attributes.filter;
+        this.select = attributes.select;
+        this.attributes = ObjectUtils.except(attributes, ["select", "filter", "maxItems", "pageSize"]);
+        this.original = attributes;
+    }
+
+    public isEmpty(): boolean {
+        return !this.original || Object.keys(this.original).length === 0;
+    }
+
+    /**
+     * Merge other list options with this one and return the newly built options
+     * @param other Other options to merge(Anything given there will override this)
+     */
+    public merge(other: ListOptions): ListOptions {
+        return new ListOptions(Object.assign({}, this.original, other.original));
+    }
+
+    /**
+     * Similar to #merge() but the given options are used as default.
+     * This means it will only merge if the attribute is not defined localy.
+     */
+    public mergeDefault(defaults: ListOptions): ListOptions {
+        return defaults.merge(this);
+    }
+
+    /**
+     * Computed value using the pageSize and maxItems provided.
+     */
+    public get maxResults(): number {
+        const { maxItems, pageSize } = this;
+        if (!pageSize) {
+            return maxItems || null;
+        }
+        if (!maxItems) {
+            return pageSize || null;
+        }
+
+        if (maxItems < pageSize) {
+            return maxItems;
+        } else {
+            return pageSize;
+        }
+    }
+}

--- a/app/services/core/rx-arm-list-proxy.ts
+++ b/app/services/core/rx-arm-list-proxy.ts
@@ -2,7 +2,7 @@ import { Type } from "@angular/core";
 import { RequestOptions, URLSearchParams } from "@angular/http";
 import { Observable } from "rxjs";
 
-import { ObjectUtils, exists } from "app/utils";
+import { exists } from "app/utils";
 import { ArmHttpService } from "../arm-http.service";
 import { CachedKeyList } from "./query-cache";
 import { RxListProxy, RxListProxyConfig } from "./rx-list-proxy";
@@ -61,8 +61,9 @@ export class RxArmListProxy<TParams, TEntity> extends RxListProxy<TParams, TEnti
     }
 
     private _requestOptions(): RequestOptions {
+        const options = this._options;
         const search = new URLSearchParams();
-        if (this._options.filter) {
+        if (options.filter) {
             search.set("$filter", this._options.filter);
         }
 
@@ -70,8 +71,13 @@ export class RxArmListProxy<TParams, TEntity> extends RxListProxy<TParams, TEnti
             search.set("$select", this._options.select);
         }
 
-        for (let key of Object.keys(ObjectUtils.except(this._options, ["filter"]))) {
-            search.set(key, this._options[key]);
+        if (this._options.pageSize || this._options.maxItems) {
+            const value = this._options.pageSize || this._options.maxItems;
+            search.set("maxResults", value.toString());
+        }
+
+        for (let key of Object.keys(options.attributes)) {
+            search.set(key, options.attributes[key]);
         }
 
         return new RequestOptions({

--- a/app/services/core/rx-arm-list-proxy.ts
+++ b/app/services/core/rx-arm-list-proxy.ts
@@ -67,13 +67,12 @@ export class RxArmListProxy<TParams, TEntity> extends RxListProxy<TParams, TEnti
             search.set("$filter", this._options.filter);
         }
 
-        if (this._options.select) {
+        if (options.select) {
             search.set("$select", this._options.select);
         }
 
-        if (this._options.pageSize || this._options.maxItems) {
-            const value = this._options.pageSize || this._options.maxItems;
-            search.set("maxResults", value.toString());
+        if (options.maxResults) {
+            search.set("maxResults", options.maxResults.toString());
         }
 
         for (let key of Object.keys(options.attributes)) {

--- a/app/services/core/rx-proxy-base.ts
+++ b/app/services/core/rx-proxy-base.ts
@@ -107,7 +107,7 @@ export abstract class RxProxyBase<TParams, TOptions extends OptionsBase, TEntity
     }
 
     public setOptions(options: TOptions, clearItems = true) {
-        this._options = Object.assign({}, options);
+        this._options = options;
         if (this._pollObservable) {
             this._pollObservable.updateKey(this._key());
         }

--- a/app/services/node-service.ts
+++ b/app/services/node-service.ts
@@ -9,11 +9,11 @@ import { FilterBuilder } from "app/utils/filter-builder";
 import { BatchClientService } from "./batch-client.service";
 
 import {
-    DataCache, RxBatchEntityProxy, RxBatchListProxy, RxEntityProxy, RxListProxy, TargetedDataCache,
-    getOnceProxy,
+    DataCache, ListOptionsAttributes, RxBatchEntityProxy, RxBatchListProxy, RxEntityProxy, RxListProxy,
+    TargetedDataCache, getOnceProxy,
 } from "./core";
 import { FileContentResult } from "./file-service";
-import { CommonListOptions, ServiceBase } from "./service-base";
+import { ServiceBase } from "./service-base";
 
 export interface NodeListParams {
     poolId?: string;
@@ -23,7 +23,7 @@ export interface NodeParams extends NodeListParams {
     id?: string;
 }
 
-export interface PoolListOptions extends CommonListOptions {
+export interface PoolListOptions extends ListOptionsAttributes {
 
 }
 
@@ -61,7 +61,7 @@ export class NodeService extends ServiceBase {
 
     public listAll(poolId: string, options: PoolListOptions = {}): Observable<List<Node>> {
         const subject = new AsyncSubject();
-        options.maxResults = 1000;
+        options.pageSize = 1000;
         const data = this.list(poolId, options);
         const sub = data.items.subscribe((x) => subject.next(x));
         data.fetchAll().subscribe(() => {
@@ -144,7 +144,7 @@ export class NodeService extends ServiceBase {
 
         this.taskManager.startTask(taskName, (bTask) => {
             const options: any = {
-                maxResults: 1000,
+                pageSize: 1000,
             };
             if (states) {
                 options.filter = FilterBuilder.or(...states.map(x => FilterBuilder.prop("state").eq(x))).toOData();
@@ -175,7 +175,7 @@ export class NodeService extends ServiceBase {
         return observable;
     }
 
-    public listNodeAgentSkus(initialOptions: any = {maxResults: 1000}): RxListProxy<{}, NodeAgentSku> {
+    public listNodeAgentSkus(initialOptions: any = { pageSize: 1000 }): RxListProxy<{}, NodeAgentSku> {
         return new RxBatchListProxy<{}, NodeAgentSku>(NodeAgentSku, this.batchService, {
             cache: (params) => this._nodeAgentSkusCache,
             proxyConstructor: (client, params, options) => client.account.listNodeAgentSkus(options),

--- a/app/services/service-base.ts
+++ b/app/services/service-base.ts
@@ -3,19 +3,8 @@ import { BehaviorSubject, Observable } from "rxjs";
 import { ServerError } from "app/models";
 import { BatchClientService } from "./batch-client.service";
 
-export interface CommonListOptions {
-    filter?: string;
-    select?: string;
-    maxResults?: number;
-}
-
 export class ServiceBase {
-    private _defaultPageSize: number = 25;
     private _loading: BehaviorSubject<boolean> = new BehaviorSubject(false);
-
-    public get maxResults(): number {
-        return this._defaultPageSize;
-    }
 
     public get loading(): Observable<boolean> {
         return this._loading.asObservable();

--- a/app/services/task-service.ts
+++ b/app/services/task-service.ts
@@ -9,6 +9,7 @@ import { FilterBuilder } from "app/utils/filter-builder";
 import { BatchClientService } from "./batch-client.service";
 import {
     DataCache,
+    ListOptionsAttributes,
     RxBatchEntityProxy,
     RxBatchListProxy,
     RxEntityProxy,
@@ -16,7 +17,7 @@ import {
     TargetedDataCache,
     getOnceProxy,
 } from "./core";
-import { CommonListOptions, ServiceBase } from "./service-base";
+import { ServiceBase } from "./service-base";
 
 export interface TaskListParams {
     jobId?: string;
@@ -31,7 +32,7 @@ export interface SubtaskListParams {
     taskId?: string;
 }
 
-export interface TaskListOptions extends CommonListOptions {
+export interface TaskListOptions extends ListOptionsAttributes {
 }
 
 @Injectable()
@@ -111,7 +112,7 @@ export class TaskService extends ServiceBase {
     public getMultiple(jobId: string, taskIds: string[], properties?: string): Observable<List<Task>> {
         let options: TaskListOptions = {
             filter: FilterBuilder.or(...taskIds.map(id => FilterBuilder.prop("id").eq(id))).toOData(),
-            maxResults: taskIds.length,
+            pageSize: taskIds.length,
         };
 
         if (properties) {

--- a/test/app/components/application/browse/application-list.component.spec.ts
+++ b/test/app/components/application/browse/application-list.component.spec.ts
@@ -57,15 +57,15 @@ describe("ApplicationListComponent", () => {
     describe("filters displayed applications", () => {
         it("listProxy doesnt filter", () => {
             component.filter = FilterBuilder.and(FilterBuilder.prop("id").startswith("app-1"), FilterBuilder.none());
-            expect(component.data.options).toEqual({});
-            expect(listProxy.options).toEqual({});
+            expect(component.data.options.isEmpty()).toBe(true);
+            expect(listProxy.options.isEmpty()).toBe(true);
         });
 
         it("applied filter does client filtering", () => {
             component.filter = FilterBuilder.and(FilterBuilder.prop("id").startswith("app-1"), FilterBuilder.none());
             fixture.detectChanges();
 
-            expect(listProxy.options).toEqual({});
+            expect(listProxy.options.isEmpty()).toBe(true);
             expect(component.displayedApplications.size).toEqual(1);
             expect(component.applications.size).toEqual(3);
         });

--- a/test/app/components/file/browse/node-file-list.component.spec.ts
+++ b/test/app/components/file/browse/node-file-list.component.spec.ts
@@ -76,21 +76,22 @@ describe("NodeFileListComponent", () => {
 
     describe("setup the filter correctly", () => {
         it("doesn't filter when both folder and filter are empty", () => {
-            expect(listProxy.options).toEqual({});
+            expect(listProxy.options.original).toEqual({});
+            expect(listProxy.options.isEmpty()).toBe(true);
         });
 
         it("filter by folder when folder is specify and filter is empty", () => {
             testComponent.folder = "startup";
             fixture.detectChanges();
 
-            expect(listProxy.options).toEqual({ filter: `startswith(name, 'startup')` });
+            expect(listProxy.options.filter).toEqual(`startswith(name, 'startup')`);
         });
 
         it("use the filter when provided and folder is not there", () => {
             testComponent.filter = FilterBuilder.prop("name").startswith("something");
             fixture.detectChanges();
 
-            expect(listProxy.options).toEqual({ filter: `startswith(name, 'something')` });
+            expect(listProxy.options.filter).toEqual(`startswith(name, 'something')`);
         });
 
         it("merge the folder and filter when both are provided", () => {
@@ -98,7 +99,7 @@ describe("NodeFileListComponent", () => {
             testComponent.filter = FilterBuilder.prop("name").startswith("something");
             fixture.detectChanges();
 
-            expect(listProxy.options).toEqual({ filter: `startswith(name, 'startup/something')` });
+            expect(listProxy.options.filter).toEqual( `startswith(name, 'startup/something')`);
         });
     });
 });

--- a/test/app/services/core/list-options.spec.ts
+++ b/test/app/services/core/list-options.spec.ts
@@ -1,0 +1,72 @@
+import { ListOptions } from "app/services/core";
+
+describe("ListOptions", () => {
+    it("should extract the filter attribute", () => {
+        const options = new ListOptions({ filter: "foo", param1: "bar" });
+        expect(options.filter).toEqual("foo");
+        expect(options.attributes).toEqual({ param1: "bar" });
+        expect(options.original).toEqual({ filter: "foo", param1: "bar" });
+    });
+
+    it("should extract the select attribute", () => {
+        const options = new ListOptions({ select: "foo", param1: "bar" });
+        expect(options.select).toEqual("foo");
+        expect(options.attributes).toEqual({ param1: "bar" });
+        expect(options.original).toEqual({ select: "foo", param1: "bar" });
+    });
+
+    it("should extract the pageSize attribute", () => {
+        const options = new ListOptions({ pageSize: 5, param1: "bar" });
+        expect(options.pageSize).toEqual(5);
+        expect(options.attributes).toEqual({ param1: "bar" });
+        expect(options.original).toEqual({ pageSize: 5, param1: "bar" });
+    });
+
+    it("should extract the maxItems attribute", () => {
+        const options = new ListOptions({ maxItems: 5, param1: "bar" });
+        expect(options.maxItems).toEqual(5);
+        expect(options.attributes).toEqual({ param1: "bar" });
+        expect(options.original).toEqual({ maxItems: 5, param1: "bar" });
+    });
+
+    describe("#maxResults", () => {
+        it("should return null if pageSize and maxItems not provided", () => {
+            const options = new ListOptions({});
+            expect(options.maxResults).toEqual(null);
+        });
+
+        it("should use pageSize if maxItems is not provided", () => {
+            const options = new ListOptions({ pageSize: 5 });
+            expect(options.maxResults).toEqual(5);
+        });
+
+        it("should use maxItems if pageSize is not provided", () => {
+            const options = new ListOptions({ maxItems: 10 });
+            expect(options.maxResults).toEqual(10);
+        });
+
+        it("should use maxItems if smaller than pageSize", () => {
+            const options = new ListOptions({ maxItems: 5, pageSize: 10 });
+            expect(options.maxResults).toEqual(5);
+        });
+
+        it("should use pageSize if smaller than maxItems", () => {
+            const options = new ListOptions({ maxItems: 5, pageSize: 10 });
+            expect(options.maxResults).toEqual(5);
+        });
+    });
+
+    describe("merge", () => {
+        it("should merge", () => {
+            const optionA = new ListOptions({ filter: "myFilter", pageSize: 20, param1: "foo", param2: "bar" });
+            const optionB = new ListOptions({ pageSize: 10, param1: "newFoo", param3: "Other" });
+            const options = optionA.merge(optionB);
+            expect(options.filter).toEqual("myFilter");
+            expect(options.pageSize).toEqual(10);
+            expect(options.original).toEqual({
+                filter: "myFilter", pageSize: 10,
+                param1: "newFoo", param2: "bar", param3: "Other",
+            });
+        })
+    })
+});

--- a/test/app/services/core/list-options.spec.ts
+++ b/test/app/services/core/list-options.spec.ts
@@ -29,6 +29,17 @@ describe("ListOptions", () => {
         expect(options.original).toEqual({ maxItems: 5, param1: "bar" });
     });
 
+    describe("#isEmpty", () => {
+        it("should return true when no params given", () => {
+            expect(new ListOptions({}).isEmpty()).toBe(true);
+        });
+
+        it("should return false when some params", () => {
+            expect(new ListOptions({ filter: "foo" }).isEmpty()).toBe(false);
+            expect(new ListOptions({ param1: "bar" }).isEmpty()).toBe(false);
+        });
+    });
+
     describe("#maxResults", () => {
         it("should return null if pageSize and maxItems not provided", () => {
             const options = new ListOptions({});
@@ -67,6 +78,6 @@ describe("ListOptions", () => {
                 filter: "myFilter", pageSize: 10,
                 param1: "newFoo", param2: "bar", param3: "Other",
             });
-        })
-    })
+        });
+    });
 });

--- a/test/app/services/core/rx-batch-list-proxy.spec.ts
+++ b/test/app/services/core/rx-batch-list-proxy.spec.ts
@@ -243,27 +243,6 @@ describe("RxBatchListProxy", () => {
             expect(queryCache).not.toBeFalsy();
             expect(queryCache.keys).toEqualImmutable(OrderedSet(["1", "2", "3"]));
         });
-
-        it("a new proxy with the same query should use the same keys and not load anything", (done) => {
-            const otherClientProxy = new MockListProxy({});
-            let otherProxy = new RxBatchListProxy(FakeModel, batchClientServiceSpy, {
-                cache: () => cache,
-                proxyConstructor: (params, options) => {
-                    otherClientProxy.options = options;
-                    return otherClientProxy;
-                },
-                initialOptions: { filter: "filter1" },
-            });
-            let otherStatus: LoadingStatus;
-            otherProxy.status.subscribe((x) => otherStatus = x);
-            otherProxy.fetchNext().subscribe(() => {
-                expect(items).toEqualImmutable(List(data[0].map((x) => new FakeModel(x))));
-                expect(otherClientProxy.fetchNext).not.toHaveBeenCalled();
-
-                expect(otherStatus).toBe(LoadingStatus.Ready);
-                done();
-            });
-        });
     });
 
     describe("when first call returns an error", () => {


### PR DESCRIPTION
This is done by changing the way the query cache works. It will now just be used to show the initial items but items will still be loaded in the background(This should also make sure the data is not out of date)
fix #297 