### PR TITLE
make background task label more friendly

### DIFF
--- a/app/components/base/background-task/background-task-tracker.scss
+++ b/app/components/base/background-task/background-task-tracker.scss
@@ -10,6 +10,10 @@
 }
 
 bl-background-task-tracker {
+    .account-dropdown [bl-dropdown-btn] {
+        width: 300px;
+    }
+
     .current-task {
         width: 100%;
         display: flex;

--- a/app/components/data/action/add/file-group-create-form.component.ts
+++ b/app/components/data/action/add/file-group-create-form.component.ts
@@ -62,7 +62,7 @@ export class FileGroupCreateFormComponent extends DynamicForm<BlobContainer, Fil
     @autobind()
     public submit(): Observable<any> {
         const formData = this.getCurrentValue();
-        const name = `Upload file group ${formData.name}`;
+        const name = `Uploading file group: ${this._formGroupName(formData.name)}`;
         this.backgroundTaskService.startTask(name, (task) => {
             const observable = this.fileGroupService.createFileGroup(formData);
             let lastData;
@@ -111,6 +111,12 @@ export class FileGroupCreateFormComponent extends DynamicForm<BlobContainer, Fil
 
     public hasValidFolder(): boolean {
         return this.folder && this.folderControl.valid;
+    }
+
+    private _formGroupName(fileGroupName: string) {
+        return fileGroupName && fileGroupName.length > 10
+        ? `${fileGroupName.substring(0, 9)}...`
+        : fileGroupName;
     }
 
     /**


### PR DESCRIPTION
Make background task label a bit wider to display more of the name. Sub-string the file group name to 10 characters and add an ellipsis if required.

Fix #704

![image](https://user-images.githubusercontent.com/10934358/30573304-2d96c2d8-9d47-11e7-8a8c-3bb90c541469.png)
