### PR TITLE
grammar issues and fix blob file explorer

### DIFF
--- a/app/components/file/browse/file-explorer/file-table-view/file-table-view.html
+++ b/app/components/file/browse/file-explorer/file-table-view/file-table-view.html
@@ -31,7 +31,7 @@
 
             <bl-no-item [itemCount]="treeNode.children.size">
                 <i icon class="fa fa-file small"></i>
-                <span no-filter>There is no files in this directory</span>
+                <span no-filter>There are no files in this directory</span>
             </bl-no-item>
         </div>
     </bl-loading>

--- a/app/components/task/details/output/task-outputs.component.ts
+++ b/app/components/task/details/output/task-outputs.component.ts
@@ -61,7 +61,9 @@ export class TaskOutputsComponent implements OnChanges, OnDestroy {
     }
 
     public ngOnDestroy() {
-        this.workspace.dispose();
+        if (this.workspace) {
+            this.workspace.dispose();
+        }
     }
 
     public selectOutputType(type: OutputType) {

--- a/app/components/task/details/output/task-outputs.component.ts
+++ b/app/components/task/details/output/task-outputs.component.ts
@@ -85,7 +85,7 @@ export class TaskOutputsComponent implements OnChanges, OnDestroy {
             });
             nodeNavigator.init();
 
-            const taskOutputPrefix = `${this.task.id}/`;
+            const taskOutputPrefix = `${this.task.id}`;
             const taskOutputNavigator = this.storageService.navigateContainerBlobs(container, taskOutputPrefix, {
                 onError: (error) => this._processBlobError(error),
             });
@@ -107,7 +107,7 @@ export class TaskOutputsComponent implements OnChanges, OnDestroy {
             return new ServerError({
                 status: 404,
                 code: "NodeNotFound",
-                message: "The node the task ran on doesn't exists anymore or is in an invalid state.",
+                message: "The node the task ran on doesn't exist anymore or is in an invalid state.",
                 original: error.original,
             });
         } else if (error.status === Constants.HttpCode.Conflict) {
@@ -139,9 +139,9 @@ export class TaskOutputsComponent implements OnChanges, OnDestroy {
     }
 
     private _fileConventionErrorMessage() {
-        return `There is no uploaded outputs\n`
+        return `There are no uploaded outputs\n`
             + `There is no blob container with the name '${this._taskOutputContainer}'\n`
-            + `Learn more here https://docs.microsoft.com/en-us/azure/batch/batch-task-output-file-conventions`;
+            + `Learn more here: https://docs.microsoft.com/en-us/azure/batch/batch-task-output-file-conventions`;
     }
 
     private _updateStateTooltip() {

--- a/app/services/file/file-navigator/file-navigator.ts
+++ b/app/services/file/file-navigator/file-navigator.ts
@@ -158,6 +158,7 @@ export class FileNavigator {
         if (!this._proxies[path]) {
             this._proxies[path] = this._loadPath(this._getFolderToLoad(path));
         }
+
         const proxy = this._proxies[path];
         const output = new AsyncSubject<FileTreeNode>();
         proxy.refresh().flatMap(() => proxy.items.first()).share().subscribe({

--- a/app/services/file/file-navigator/file-navigator.ts
+++ b/app/services/file/file-navigator/file-navigator.ts
@@ -192,7 +192,7 @@ export class FileNavigator {
     }
 
     private _getFolderToLoad(path: string, asDirectory = true) {
-        let fullPath = [this.basePath, path].filter(x => Boolean(x)).join("/");
+        let fullPath = [this._normalizedBasePath, path].filter(x => Boolean(x)).join("");
         if (fullPath) {
             if (asDirectory) {
                 return CloudPathUtils.asBaseDirectory(fullPath);
@@ -201,5 +201,11 @@ export class FileNavigator {
             }
         }
         return null;
+    }
+
+    private get _normalizedBasePath() {
+        return this.basePath
+            ? CloudPathUtils.asBaseDirectory(this.basePath)
+            : this.basePath;
     }
 }

--- a/test/app/components/task/details/output/task-output.component.spec.ts
+++ b/test/app/components/task/details/output/task-output.component.spec.ts
@@ -90,6 +90,6 @@ describe("TaskLogComponent", () => {
         expect(fileServiceSpy.navigateTaskFile).toHaveBeenCalledOnce();
         expect(fileServiceSpy.navigateTaskFile).toHaveBeenCalledWith("job-1", "task-1", jasmine.anything());
         expect(storageServiceSpy.navigateContainerBlobs).toHaveBeenCalledOnce();
-        expect(storageServiceSpy.navigateContainerBlobs).toHaveBeenCalledWith("job-1", "task-1/", jasmine.anything());
+        expect(storageServiceSpy.navigateContainerBlobs).toHaveBeenCalledWith("job-1", "task-1", jasmine.anything());
     }));
 });

--- a/test/app/services/file/file-navigator/file-tree.model.spec.ts
+++ b/test/app/services/file/file-navigator/file-tree.model.spec.ts
@@ -136,7 +136,7 @@ describe("FileTreeStructure", () => {
             `));
         });
 
-        it("should add nested files correctly when tree as a basePath", () => {
+        it("should add nested files correctly when tree has a basePath", () => {
             tree = new FileTreeStructure("startup/wd");
             const files = List([
                 makeFile("startup/wd/stdout.txt"),


### PR DESCRIPTION
change a couple of words in notifications
fix the blob file explorer by removing training slash that was messing up the storage prefix.