### PR TITLE
Fix osx copy and paste shortcuts not working in prod

### DIFF
--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -1,4 +1,4 @@
-import { app, dialog, ipcMain, protocol } from "electron";
+import { Menu, app, dialog, ipcMain, protocol } from "electron";
 import * as path from "path";
 app.setPath("userData", path.join(app.getPath("appData"), "batch-labs"));
 
@@ -23,6 +23,31 @@ function startApplication() {
     // batchLabsApp.debugCrash();
 
     batchLabsApp.start();
+
+    if (process.platform === "darwin") {
+        // Create our menu entries so that we can use MAC shortcuts
+        Menu.setApplicationMenu(Menu.buildFromTemplate([
+            {
+                label: "Application",
+                submenu: [
+                    { label: "Quit", accelerator: "Command+Q", click: () => app.quit() },
+                ],
+            },
+            {
+                label: "Edit",
+                submenu: [
+                    { role: "undo" },
+                    { role: "redo" },
+                    { type: "separator" },
+                    { role: "cut" },
+                    { role: "copy" },
+                    { role: "paste" },
+                    { role: "delete" },
+                    { role: "selectall" },
+                ],
+            },
+        ]));
+    }
 }
 
 // This method will be called when Electron has finished


### PR DESCRIPTION
fix #727 