### PR TITLE
List view loads from cache but always query server right away to check for changes

### DIFF
--- a/app/components/account/details/programatic-usage/programing-sample/samples/aad/node.js.template
+++ b/app/components/account/details/programatic-usage/programing-sample/samples/aad/node.js.template
@@ -6,7 +6,9 @@ const tenantId = "{1}";
 const clientId = "{2}";
 const secret = "{3}";
 
-async function run(batchClient) {
+async function run() {
+    const credentials = await loginWithServicePrincipalSecret(clientId, secret, tenantId, { tokenAudience: "https://batch.core.windows.net/" });
+    const batchClient = new ServiceClient(credentials, accountUrl);
     const jobs = await batchClient.job.list();
 
     for (const job of jobs) {
@@ -15,10 +17,4 @@ async function run(batchClient) {
     }
 }
 
-loginWithServicePrincipalSecret(clientId, secret, tenantId, (err, credentials) => {
-    const batchClient = new ServiceClient(credentials, accountUrl);
-
-    run(batchClient).then(() => {
-        process.exit();
-    });
-});
+run().catch(e => console.error("Error", e));

--- a/app/services/core/data-cache.ts
+++ b/app/services/core/data-cache.ts
@@ -149,7 +149,7 @@ export class DataCache<T> {
             return false;
         }
         this._deleted.next(key);
-        this._items.next(this._items.getValue().delete(key));
+        this._items.next(this._items.value.delete(key));
         return true;
     }
 

--- a/app/services/core/data/list-view.ts
+++ b/app/services/core/data/list-view.ts
@@ -229,8 +229,8 @@ export class ListView<TEntity, TParams> extends GenericView<TEntity, TParams, Li
         const response = this._getter.fetchFromCache(this._params, this._options);
         if (!response) { return false; }
         this._itemKeys.next(this._retrieveKeys(response.items));
-        this._lastRequest = { params: this._params, options: this._options };
-        this._hasMore.next(Boolean(response.nextLink));
+        // this._lastRequest = { params: this._params, options: this._options };
+        // this._hasMore.next(Boolean(response.nextLink));
         this._status.next(LoadingStatus.Ready);
         return true;
     }

--- a/app/services/task-service.ts
+++ b/app/services/task-service.ts
@@ -45,6 +45,10 @@ export class TaskService extends ServiceBase {
 
     private _basicProperties: string = "id,state,dependsOn";
     private _cache = new TargetedDataCache<TaskListParams, Task>({
+        // dependsOn: {
+        //     cache: jobService.cache,
+        //     key: (job: Job) => ({jobId: jobId})
+        // },
         key: ({ jobId }) => jobId,
     });
     private _getter: BatchEntityGetter<Task, TaskParams>;

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
 websockets==3.3
 pylint==1.6.5
 azure-batch-extensions==0.2.0
-pyinstaller==3.3
+pyinstaller==3.3.1


### PR DESCRIPTION
fix #1065 
Currently if data was in the cache it would load from there but not update with server data unless explicitly refershed which leads to weird data if deleting a job and recreating and navigating to it seeing deleted job task.

Still try to load from cache to have a fast loading if quickly switching between elements.

Could maybe add a timestamp to the cache and not even try to load from it if the data is too old