### PR TITLE
Allow fixed size table columns for flex-boxes

### DIFF
--- a/app/components/account/details/account-details.html
+++ b/app/components/account/details/account-details.html
@@ -46,7 +46,7 @@
                             <bl-table class="dashboard">
                                 <bl-row *ngFor="let job of (jobData.items | async);trackBy: trackByFn" [link]="['/jobs/', job.id]" [key]="job.id">
                                     <bl-cell [value]="job.id"></bl-cell>
-                                    <bl-cell style="text-align:right; color:steelblue;width:75px" [value]="job.state"></bl-cell>
+                                    <bl-cell class="fixed-size right" style="color:steelblue; flex-basis:75px;" [value]="job.state"></bl-cell>
                                 </bl-row>
                             </bl-table>
                         </bl-loading>
@@ -73,10 +73,10 @@
                             <bl-table class="dashboard">
                                 <bl-row *ngFor="let pool of (poolData.items | async);trackBy: trackByFn" [link]="['/pools/', pool.id]" [key]="pool.id">
                                     <bl-cell [value]="pool.id"></bl-cell>
-                                    <bl-cell style="width: 20px">
+                                    <bl-cell class="fixed-size" style="flex-basis:30px;">
                                         <i aria-hidden="true" class="fa fa-{{pool.osIconName()}}"></i>
                                     </bl-cell>
-                                    <bl-cell style="text-align: right; width: 60px">
+                                    <bl-cell class="fixed-size right" style="flex-basis:60px;">
                                         <bl-pool-nodes-preview [pool]="pool"></bl-pool-nodes-preview>
                                     </bl-cell>
                                 </bl-row>

--- a/app/components/account/details/account-details.html
+++ b/app/components/account/details/account-details.html
@@ -46,7 +46,7 @@
                             <bl-table class="dashboard">
                                 <bl-row *ngFor="let job of (jobData.items | async);trackBy: trackByFn" [link]="['/jobs/', job.id]" [key]="job.id">
                                     <bl-cell [value]="job.id"></bl-cell>
-                                    <bl-cell class="fixed-size right" style="color:steelblue; flex-basis:75px;" [value]="job.state"></bl-cell>
+                                    <bl-cell class="fixed-size text-right" style="color:steelblue; flex-basis:75px;" [value]="job.state"></bl-cell>
                                 </bl-row>
                             </bl-table>
                         </bl-loading>
@@ -76,7 +76,7 @@
                                     <bl-cell class="fixed-size" style="flex-basis:30px;">
                                         <i aria-hidden="true" class="fa fa-{{pool.osIconName()}}"></i>
                                     </bl-cell>
-                                    <bl-cell class="fixed-size right" style="flex-basis:60px;">
+                                    <bl-cell class="fixed-size text-right" style="flex-basis:60px;">
                                         <bl-pool-nodes-preview [pool]="pool"></bl-pool-nodes-preview>
                                     </bl-cell>
                                 </bl-row>
@@ -117,7 +117,7 @@
                     <bl-clickable>View all packages</bl-clickable>
                 </div>
             </bl-card>
-            <span style="width:100%;display:inline-block"></span>
+            <span style="width:100%; display:inline-block;"></span>
         </div>
     </div>
 </bl-loading>

--- a/src/@batch-flask/ui/table/table.scss
+++ b/src/@batch-flask/ui/table/table.scss
@@ -145,6 +145,15 @@ bl-table {
         position: relative;
         white-space: nowrap;
 
+        &.fixed-size {
+            flex-grow:0;
+            flex-shrink:0;
+        }
+
+        &.right {
+            text-align:right;
+        }
+
         .cell-value {
             width: 98%;
             overflow: hidden;

--- a/src/@batch-flask/ui/table/table.scss
+++ b/src/@batch-flask/ui/table/table.scss
@@ -150,10 +150,6 @@ bl-table {
             flex-shrink:0;
         }
 
-        &.right {
-            text-align:right;
-        }
-
         .cell-value {
             width: 98%;
             overflow: hidden;


### PR DESCRIPTION
Added CSS for bl-cell that allows for fixed size columns rather than them all defaulting to the same width. Changed account overview to use new CSS.

Fix: #1136 