### PR TITLE
Setup file-group sync via plugin before submit

### DIFF
--- a/app/components/data/action/add/file-group-create-form.component.ts
+++ b/app/components/data/action/add/file-group-create-form.component.ts
@@ -34,8 +34,9 @@ interface DataTotals {
 export class FileGroupCreateFormComponent extends DynamicForm<BlobContainer, FileGroupCreateDto> implements OnDestroy {
     public groupExists: boolean;
     public title: string = "Create file group";
-    public description: string = "Upload files into a managed storage container that you can use " +
-        "for resource files in your jobs and tasks";
+    public description: string = "Upload files into a managed storage container that is used to supply " +
+        "resource files for your jobs and tasks. File groups require a 'fgrp-' prefix which is added " +
+        "automatically on creation.";
     public createEmptyGroup: boolean = false;
     public showCreateEmptyChk: boolean = true;
     public modifyExisting: boolean = false;

--- a/app/components/data/action/add/file-group-create-form.component.ts
+++ b/app/components/data/action/add/file-group-create-form.component.ts
@@ -118,7 +118,6 @@ export class FileGroupCreateFormComponent extends DynamicForm<BlobContainer, Fil
                     this.title = "Add more files to file group";
                     this.description = "Add more files to an already existing file group. " +
                         "Any files that exist already will be updated 'only' if they have changed.";
-                    this.form.controls.name.disable();
                     this.modifyExisting = true;
                 },
                 error: () => {

--- a/app/components/data/action/add/file-group-create-form.html
+++ b/app/components/data/action/add/file-group-create-form.html
@@ -3,7 +3,7 @@
         <bl-form-section title="General info" subtitle="Basic information about the file group">
             <div class="form-element">
                 <mat-form-field>
-                    <input matInput formControlName="name" placeholder="File group name">
+                    <input matInput formControlName="name" placeholder="File group name (automatically prefixed with fgrp-)">
                 </mat-form-field>
                 <bl-error controlName="name" code="required">The file group name is a required field</bl-error>
                 <bl-error controlName="name" code="maxlength">The file group name has a maximum length of 64 characters</bl-error>

--- a/app/components/data/action/add/file-group-create-form.html
+++ b/app/components/data/action/add/file-group-create-form.html
@@ -9,7 +9,7 @@
                 <bl-error controlName="name" code="maxlength">The file group name has a maximum length of 64 characters</bl-error>
                 <bl-error controlName="name" code="pattern">The file group name can contain any combination of lowercase alphanumeric characters including single hyphens</bl-error>
             </div>
-            <p *ngIf="groupExists" class="exists">This file group already exists, any selected files will be added to this existing group</p>
+            <p *ngIf="groupExists" class="exists">This file group already exists. Any new files will be added to this existing group, existing files will be uploaded only if they have been modified.</p>
             <div class="form-element">
                 <mat-checkbox *ngIf="showCreateEmptyChk" (change)="createEmptyCheckChanged($event)" color="primary">Create an empty file group</mat-checkbox>
             </div>

--- a/app/components/data/action/add/file-group-create-form.html
+++ b/app/components/data/action/add/file-group-create-form.html
@@ -11,7 +11,7 @@
             </div>
             <p *ngIf="groupExists" class="exists">This file group already exists, any selected files will be added to this existing group</p>
             <div class="form-element">
-                <mat-checkbox *ngIf="!modifyExisting" (change)="createEmptyCheckChanged($event)" color="primary">Create an empty file group</mat-checkbox>
+                <mat-checkbox *ngIf="showCreateEmptyChk" (change)="createEmptyCheckChanged($event)" color="primary">Create an empty file group</mat-checkbox>
             </div>
         </bl-form-section>
 

--- a/app/components/data/action/add/file-group-create-form.scss
+++ b/app/components/data/action/add/file-group-create-form.scss
@@ -16,6 +16,6 @@ bl-file-group-create-form {
 
     p.exists {
         margin-top: -10px;
-        color: $validation-error-color;
+        color: $infoText;
     }
 }

--- a/app/components/data/shared/file-group-picker/file-group-picker.component.ts
+++ b/app/components/data/shared/file-group-picker/file-group-picker.component.ts
@@ -94,7 +94,8 @@ export class FileGroupPickerComponent implements ControlValueAccessor, OnInit, O
         if (!event.source.value && event.isUserInput) {
             const sidebar = this.sidebarManager.open("Add a new file group", FileGroupCreateFormComponent);
             sidebar.afterCompletion.subscribe(() => {
-                this.value.setValue(sidebar.component.getCurrentValue().name);
+                const newFileGroupName = sidebar.component.getCurrentValue().name;
+                this.value.setValue(this.storageService.addFileGroupPrefix(newFileGroupName));
             });
         }
     }

--- a/app/components/data/shared/file-group-picker/file-group-picker.component.ts
+++ b/app/components/data/shared/file-group-picker/file-group-picker.component.ts
@@ -33,7 +33,7 @@ export class FileGroupPickerComponent implements ControlValueAccessor, OnInit, O
     public fileGroupsData: ListView<BlobContainer, ListContainerParams>;
     public warning = false;
 
-    private _propagateChange: (value: any[]) => void = null;
+    private _propagateChange: (value: any) => void = null;
     private _subscriptions: Subscription[] = [];
     private _loading: boolean = true;
 
@@ -56,7 +56,7 @@ export class FileGroupPickerComponent implements ControlValueAccessor, OnInit, O
         this._subscriptions.push(this.value.valueChanges.debounceTime(400).distinctUntilChanged().subscribe((value) => {
             this._checkValid(value);
             if (this._propagateChange) {
-                this._propagateChange(value && value.replace(Constants.ncjFileGroupPrefix, ""));
+                this._propagateChange(value && this.storageService.removeFileGroupPrefix(value));
             }
         }));
     }

--- a/app/components/market/submit/parameter-input/parameter-input.component.spec.ts
+++ b/app/components/market/submit/parameter-input/parameter-input.component.spec.ts
@@ -17,6 +17,8 @@ import { FileGroupSasComponent } from "app/components/data/shared/file-group-sas
 import { NcjParameterExtendedType, NcjParameterWrapper, ParameterInputComponent } from "app/components/market/submit";
 import { BatchApplication, NcjParameterRawType } from "app/models";
 import { StorageService } from "app/services";
+import { Constants } from "app/utils";
+
 import * as Fixtures from "test/fixture";
 import { updateInput } from "test/utils/helpers";
 import { MockListView } from "test/utils/mocks";
@@ -79,6 +81,9 @@ describe("ParameterInputComponent", () => {
             generateSharedAccessContainerUrl: (containerId, accessPolicy) => {
                 return Observable.of(`https://${containerId}.com?sastoken`);
             },
+            addFileGroupPrefix: jasmine.createSpy("addFileGroupPrefix").and.callFake((fgName) => {
+                return `${Constants.ncjFileGroupPrefix}${fgName}`;
+            }),
         };
 
         sidebarSpy = {

--- a/app/components/market/submit/parameter-input/parameter-input.component.ts
+++ b/app/components/market/submit/parameter-input/parameter-input.component.ts
@@ -3,7 +3,7 @@ import { ControlValueAccessor, FormControl, NG_VALIDATORS, NG_VALUE_ACCESSOR, Va
 import { Subscription } from "rxjs";
 
 import { NcjParameterRawType } from "app/models";
-import { Constants } from "common";
+import { StorageService } from "app/services";
 import { NcjParameterExtendedType, NcjParameterWrapper } from "../market-application.model";
 import "./parameter-input.scss";
 
@@ -27,7 +27,7 @@ export class ParameterInputComponent implements ControlValueAccessor, OnChanges,
     private _propagateChange: (value: any) => void = null;
     private _subs: Subscription[] = [];
 
-    constructor() {
+    constructor(private storageService: StorageService) {
         this._subs.push(this.parameterValue.valueChanges.distinctUntilChanged()
             .subscribe((query: string) => {
                 if (this._propagateChange) {
@@ -44,7 +44,7 @@ export class ParameterInputComponent implements ControlValueAccessor, OnChanges,
     }
 
     public getContainerFromFileGroup(fileGroup: string) {
-        return fileGroup && `${Constants.ncjFileGroupPrefix}${fileGroup}`;
+        return this.storageService.addFileGroupPrefix(fileGroup);
     }
 
     public ngOnDestroy(): void {
@@ -52,10 +52,9 @@ export class ParameterInputComponent implements ControlValueAccessor, OnChanges,
     }
 
     public writeValue(value: any) {
-        // persisted value will not have the file group prefix. need to add it
-        // to fix validation error for recent templates.
-        if (this.parameter.type === NcjParameterExtendedType.fileGroup &&
-            Boolean(value) && !value.startsWith(Constants.ncjFileGroupPrefix)) {
+        // persisted value will not have the file group prefix. need to add it to fix
+        // validation error for recent templates.
+        if (this.parameter.type === NcjParameterExtendedType.fileGroup && Boolean(value)) {
             value = this.getContainerFromFileGroup(value);
         }
 

--- a/app/components/market/submit/submit-ncj-template.component.spec.ts
+++ b/app/components/market/submit/submit-ncj-template.component.spec.ts
@@ -216,7 +216,9 @@ describe("SubmitNcjTemplateComponent", () => {
     describe("Change query parameter to not use autopool", () => {
         beforeEach(() => {
             queryParameters["auto-pool"] = "1";
-            activatedRouteSpy.queryParams.next(queryParameters);
+            fixture = TestBed.createComponent(TestComponent);
+            de = fixture.debugElement.query(By.css("bl-submit-ncj-template"));
+            component = de.componentInstance;
             fixture.detectChanges();
         });
 

--- a/app/components/market/submit/submit-ncj-template.component.spec.ts
+++ b/app/components/market/submit/submit-ncj-template.component.spec.ts
@@ -21,6 +21,8 @@ import { PoolPickerComponent } from "app/components/job/action/add";
 import { ParameterInputComponent, SubmitNcjTemplateComponent } from "app/components/market/submit";
 import { NcjJobTemplate, NcjParameterRawType, NcjPoolTemplate, NcjTemplateMode, Pool } from "app/models";
 import { NcjSubmitService, NcjTemplateService, PoolService, StorageService, VmSizeService } from "app/services";
+import { Constants } from "app/utils";
+
 import * as Fixtures from "test/fixture";
 import { MockListView } from "test/utils/mocks";
 import { NoItemMockComponent } from "test/utils/mocks/components";
@@ -102,8 +104,8 @@ describe("SubmitNcjTemplateComponent", () => {
 
     const blendFile = "myscene.blend";
     const queryParameters = {
-        useAutoPool: "0",
-        blendFile: blendFile,
+        "auto-pool": "0",
+        "blendFile": blendFile,
     };
 
     beforeEach(() => {
@@ -151,6 +153,9 @@ describe("SubmitNcjTemplateComponent", () => {
         storageServiceSpy = {
             onContainerAdded: new Subject(),
             containerListView: () => listProxy,
+            addFileGroupPrefix: jasmine.createSpy("addFileGroupPrefix").and.callFake((fgName) => {
+                return `${Constants.ncjFileGroupPrefix}${fgName}`;
+            }),
         };
 
         dialogSpy = {
@@ -210,7 +215,7 @@ describe("SubmitNcjTemplateComponent", () => {
 
     describe("Change query parameter to not use autopool", () => {
         beforeEach(() => {
-            queryParameters.useAutoPool = "1";
+            queryParameters["auto-pool"] = "1";
             activatedRouteSpy.queryParams.next(queryParameters);
             fixture.detectChanges();
         });

--- a/app/components/market/submit/submit-ncj-template.component.ts
+++ b/app/components/market/submit/submit-ncj-template.component.ts
@@ -71,8 +71,6 @@ export class SubmitNcjTemplateComponent implements OnInit, OnChanges, OnDestroy 
         const autoPoolParam = Constants.KnownQueryParameters.useAutoPool;
         this._routeParametersSub = this.activatedRoute.queryParams.subscribe((params: any) => {
             this._queryParameters = Object.assign({}, params);
-            console.log("queryParams.subscribe :: ", this._queryParameters);
-
             if (this._queryParameters[autoPoolParam]) {
                 const modeAutoSelect = Boolean(parseInt(this._queryParameters[autoPoolParam], 10))
                     ? NcjTemplateMode.NewPoolAndJob
@@ -209,7 +207,6 @@ export class SubmitNcjTemplateComponent implements OnInit, OnChanges, OnDestroy 
     }
 
     private _syncFileGroup(container: string, paths: string[]) {
-        console.log("_syncFileGroup called with: ", container, paths);
         const sidebarRef = this.sidebarManager.open("sync-file-group", FileGroupCreateFormComponent);
 
         sidebarRef.component.setValue(new FileGroupCreateDto({
@@ -221,11 +218,10 @@ export class SubmitNcjTemplateComponent implements OnInit, OnChanges, OnDestroy 
         sidebarRef.afterCompletion.subscribe(() => {
             this.storageService.onContainerUpdated.next();
             const fileGroupName = sidebarRef.component.getCurrentValue().name;
-            console.log("sidebarRef.afterCompletion: ", fileGroupName);
 
-            if (fileGroupName && this._queryParameters[Constants.KnownQueryParameters.assetParamName]) {
+            if (fileGroupName && this._queryParameters[Constants.KnownQueryParameters.inputParameter]) {
                 // we know what the control is called so update it with the new value
-                const parameterName = this._queryParameters[Constants.KnownQueryParameters.assetParamName];
+                const parameterName = this._queryParameters[Constants.KnownQueryParameters.inputParameter];
                 const fileGroupContainer = this.storageService.addFileGroupPrefix(fileGroupName);
                 (this.form.controls.job as FormGroup).controls[parameterName].setValue(fileGroupContainer);
             }

--- a/app/components/market/submit/submit-ncj-template.component.ts
+++ b/app/components/market/submit/submit-ncj-template.component.ts
@@ -68,19 +68,11 @@ export class SubmitNcjTemplateComponent implements OnInit, OnChanges, OnDestroy 
     }
 
     public ngOnInit() {
-        const autoPoolParam = Constants.KnownQueryParameters.useAutoPool;
         this._routeParametersSub = this.activatedRoute.queryParams.subscribe((params: any) => {
             this._queryParameters = Object.assign({}, params);
-            if (this._queryParameters[autoPoolParam]) {
-                const modeAutoSelect = Boolean(parseInt(this._queryParameters[autoPoolParam], 10))
-                    ? NcjTemplateMode.NewPoolAndJob
-                    : NcjTemplateMode.ExistingPoolAndJob;
-
-                this.pickMode(modeAutoSelect);
-            }
-
             if (!this._loaded) {
                 // subscribe is fired every time a value changes now so don't want to re-apply
+                this._checkForAutoPoolParam();
                 this._checkForAssetsToSync();
                 this._applyinitialData();
                 this._loaded = true;
@@ -193,6 +185,17 @@ export class SubmitNcjTemplateComponent implements OnInit, OnChanges, OnDestroy 
         this._saveTemplateAsRecent();
         return this.ncjSubmitService.createPool(this.poolTemplate, this.poolParams.value)
             .cascade((data) => this._redirectToPool(data.id));
+    }
+
+    private _checkForAutoPoolParam() {
+        const autoPoolParam = Constants.KnownQueryParameters.useAutoPool;
+        if (this._queryParameters[autoPoolParam]) {
+            const modeAutoSelect = Boolean(parseInt(this._queryParameters[autoPoolParam], 10))
+                ? NcjTemplateMode.NewPoolAndJob
+                : NcjTemplateMode.ExistingPoolAndJob;
+
+            this.pickMode(modeAutoSelect);
+        }
     }
 
     private _checkForAssetsToSync() {

--- a/app/components/market/submit/submit-ncj-template.html
+++ b/app/components/market/submit/submit-ncj-template.html
@@ -27,5 +27,4 @@
     <bl-button [title]="submitToolTip" [disabled]="!isFormValid()" [action]="submit" type="wide" class="submit-job" color="success">
         <i class="fa fa-play"></i>
     </bl-button>
-    <mat-checkbox (change)="blockRedirectionCheckChanged($event)" color="primary" [disabled]="!isFormValid()">Do not redirect</mat-checkbox>
 </div>

--- a/app/services/storage.service.ts
+++ b/app/services/storage.service.ts
@@ -469,8 +469,29 @@ export class StorageService {
      * Return the container name from a file group name
      * @param fileGroupName Name of the file group
      */
-    public fileGroupContainer(fileGroupName: string) {
-        return `${Constants.ncjFileGroupPrefix}${fileGroupName}`;
+    public addFileGroupPrefix(fileGroupName: string) {
+        return !this.isFileGroup(fileGroupName)
+            ? `${Constants.ncjFileGroupPrefix}${fileGroupName}`
+            : fileGroupName;
+    }
+
+    /**
+     * Return the file group name sans prefix from a container name that possibly
+     * includes the file group prefix. Ignore if has no prefix.
+     * @param containerName Name of the container including prefix
+     */
+    public removeFileGroupPrefix(containerName: string) {
+        return this.isFileGroup(containerName)
+            ? containerName.replace(Constants.ncjFileGroupPrefix, "")
+            : containerName;
+    }
+
+    /**
+     * Returns true if the file group starts with the correct prefix
+     * @param fileGroup Name of the name to test
+     */
+    public isFileGroup(fileGroup: string) {
+        return fileGroup && fileGroup.startsWith(Constants.ncjFileGroupPrefix);
     }
 
     /**

--- a/src/@batch-flask/ui/notifications/notification.ts
+++ b/src/@batch-flask/ui/notifications/notification.ts
@@ -16,7 +16,7 @@ export interface NotificationConfig {
     /**
      * Time(in milliseconds) it take for the notification to disapear automatically.
      * This is independent from the persist setting.
-     * @default 3500ms
+     * @default 3000ms
      */
     autoDismiss?: number;
     /**

--- a/src/client/core/batchlabs-application.ts
+++ b/src/client/core/batchlabs-application.ts
@@ -155,25 +155,7 @@ export class BatchLabsApplication {
 
     public openFromArguments(argv: string[]): MainWindow {
         if (ClientConstants.isDev) {
-            // return this.windows.openNewWindow(null, false);
-            const route = "route/market/blender/actions/render-movie-linux/submit";
-            const account = "/subscriptions/21dd4ed1-9ce5-4633-b202-a27b157920dc/resourceGroups/"
-                + "ascobierg/providers/Microsoft.Batch/batchAccounts/andrew1973";
-
-            const assets = "D:\\Azure\\assets\\multi-sources\\monster.blend";
-
-            const params = `sessionId=${Date.now()}`
-                + `&accountId=${account}`
-                + "&blendFile=monster.blend"
-                + "&frameStart=1"
-                + "&frameEnd=1"
-                + "&auto-pool=0"
-                + "&input-parameter=inputData"
-                + "&asset-container=blender-monster-inputs"
-                + `&asset-paths=${assets}`
-                + "";
-
-            return this.windows.openNewWindow(`ms-batchlabs://${route}?${params}`, false);
+            return this.windows.openNewWindow(null, false);
         }
         const program = commander
             .version(app.getVersion())

--- a/src/client/core/batchlabs-application.ts
+++ b/src/client/core/batchlabs-application.ts
@@ -160,19 +160,16 @@ export class BatchLabsApplication {
             const account = "/subscriptions/21dd4ed1-9ce5-4633-b202-a27b157920dc/resourceGroups/"
                 + "ascobierg/providers/Microsoft.Batch/batchAccounts/andrew1973";
 
-            const assets = "D:\\Azure\\assets\\multi-sources\\monster.blend"
-                + ",D:\\Azure\\assets\\multi-sources\\path1"
-                + ",D:\\Azure\\assets\\multi-sources\\path2";
+            const assets = "D:\\Azure\\assets\\multi-sources\\monster.blend";
 
             const params = `sessionId=${Date.now()}`
                 + `&accountId=${account}`
-                + "&auto-pool=0"
                 + "&blendFile=monster.blend"
-                + "&frameStart=10"
-                + "&frameEnd=150"
-                + "&inputData=fgrp-monster"
-                + "&asset-param-name=inputData"
-                + "&asset-container=monster"
+                + "&frameStart=1"
+                + "&frameEnd=1"
+                + "&auto-pool=0"
+                + "&input-parameter=inputData"
+                + "&asset-container=blender-monster-inputs"
                 + `&asset-paths=${assets}`
                 + "";
 

--- a/src/client/core/batchlabs-application.ts
+++ b/src/client/core/batchlabs-application.ts
@@ -155,7 +155,23 @@ export class BatchLabsApplication {
 
     public openFromArguments(argv: string[]): MainWindow {
         if (ClientConstants.isDev) {
-            return this.windows.openNewWindow(null, false);
+            // return this.windows.openNewWindow(null, false);
+            const route = "route/market/blender/actions/render-movie-linux/submit";
+            const assets = "D:\\Azure\\assets\\multi-sources\\monster.blend"
+                + ",D:\\Azure\\assets\\multi-sources\\path1"
+                + ",D:\\Azure\\assets\\multi-sources\\path2";
+
+            const params = "auto-pool=0"
+                + "&blendFile=monster.blend"
+                + "&frameStart=10"
+                + "&frameEnd=150"
+                + "&inputData=fgrp-monster"
+                + "&asset-param-name=inputData"
+                + "&asset-container=monster"
+                + `&asset-paths=${assets}`
+                + "";
+
+            return this.windows.openNewWindow(`ms-batchlabs://${route}?${params}`, false);
         }
         const program = commander
             .version(app.getVersion())

--- a/src/client/core/batchlabs-application.ts
+++ b/src/client/core/batchlabs-application.ts
@@ -157,11 +157,16 @@ export class BatchLabsApplication {
         if (ClientConstants.isDev) {
             // return this.windows.openNewWindow(null, false);
             const route = "route/market/blender/actions/render-movie-linux/submit";
+            const account = "/subscriptions/21dd4ed1-9ce5-4633-b202-a27b157920dc/resourceGroups/"
+                + "ascobierg/providers/Microsoft.Batch/batchAccounts/andrew1973";
+
             const assets = "D:\\Azure\\assets\\multi-sources\\monster.blend"
                 + ",D:\\Azure\\assets\\multi-sources\\path1"
                 + ",D:\\Azure\\assets\\multi-sources\\path2";
 
-            const params = "auto-pool=0"
+            const params = `sessionId=${Date.now()}`
+                + `&accountId=${account}`
+                + "&auto-pool=0"
                 + "&blendFile=monster.blend"
                 + "&frameStart=10"
                 + "&frameEnd=150"

--- a/src/common/constants/constants.ts
+++ b/src/common/constants/constants.ts
@@ -33,7 +33,7 @@ export const forms = {
             displayName: 1024,
             applicationName: 64,
             version: 64,
-            fileGroup: 63,
+            fileGroup: 55,
         },
         regex: {
             id: /^[\w\_-]+$/i,
@@ -199,7 +199,7 @@ export const ListPageSizes = {
 
 export const KnownQueryParameters = {
     useAutoPool: "auto-pool",
-    assetParamName: "asset-param-name",
+    inputParameter: "input-parameter",
     assetContainer: "asset-container",
     assetPaths: "asset-paths",
 };

--- a/src/common/constants/constants.ts
+++ b/src/common/constants/constants.ts
@@ -198,5 +198,8 @@ export const ListPageSizes = {
 };
 
 export const KnownQueryParameters = {
-    useAutoPool: "useAutoPool",
+    useAutoPool: "auto-pool",
+    assetParamName: "asset-param-name",
+    assetContainer: "asset-container",
+    assetPaths: "asset-paths",
 };


### PR DESCRIPTION
Fix: #1180

When submitting a job from a plugin, if you supply a container name and a set of paths it will automatically populate the file group create/manage form.