### PR TITLE
Correct spelling of 'successful'.

### DIFF
--- a/app/services/local-file-storage.service.ts
+++ b/app/services/local-file-storage.service.ts
@@ -21,7 +21,7 @@ export class LocalFileStorage {
 
     /**
      * @param key Key where the data is store
-     * @returns Observable which will resolve the data contained in the file if successfull or reject if any error
+     * @returns Observable which will resolve the data contained in the file if successful or reject if any error
      */
     public get<T>(key: string): Observable<T> {
         return Observable.fromPromise(this.getAsync(key));

--- a/src/@batch-flask/ui/entity-commands/entity-command.ts
+++ b/src/@batch-flask/ui/entity-commands/entity-command.ts
@@ -120,7 +120,7 @@ export class EntityCommand<TEntity extends ActionableEntity, TOptions = void> {
         const label = this.label(entity);
         this.performAction(entity, options).subscribe({
             next: () => {
-                this._notifySuccess(`${label} was successfull.`, `${entity.id}`);
+                this._notifySuccess(`${label} was successful.`, `${entity.id}`);
                 this.definition.get((entity as any).id).subscribe({
                     error: () => null,
                 });
@@ -142,7 +142,7 @@ export class EntityCommand<TEntity extends ActionableEntity, TOptions = void> {
                 func: () => this.performAction(entity, options),
             };
         })).subscribe((result) => {
-            this._notifySuccess(`${label} was successfull.`,
+            this._notifySuccess(`${label} was successful.`,
                 `${result.succeeded}/${entities.length}`);
         });
     }

--- a/src/client/core/aad/authentication/authentication.service.ts
+++ b/src/client/core/aad/authentication/authentication.service.ts
@@ -59,7 +59,7 @@ export class AuthenticationService {
      * Authorize the user.
      * @param silent If set to true it will not ask the user for prompt. (i.e prompt=none for AD)
      *      This means the request will fail if the user didn't give consent yet or it expired
-     * @returns Observable with the successfull AuthorizeResult.
+     * @returns Observable with the successful AuthorizeResult.
      *      If silent is true and the access fail the observable will return and error of type AuthorizeError
      */
     public async authorize(tenantId: string, silent = false): Promise<AuthorizeResult> {


### PR DESCRIPTION
Spelling of 'successful' was incorrect. Mainly an issue in the user-facing notification, but updated all references in the project.