### PR TITLE
Fix: Show better errors form python server when folder is empty

### DIFF
--- a/app/components/data/action/add/file-group-create-form.component.ts
+++ b/app/components/data/action/add/file-group-create-form.component.ts
@@ -197,13 +197,15 @@ export class FileGroupCreateFormComponent extends DynamicForm<BlobContainer, Fil
 
                     return createObs;
                 }).finally(() => {
-                    task.progress.next(100);
-                    const fileGroupName = this.fileGroupService.addFileGroupPrefix(formData.name);
-                    this.storageContainerService.onContainerAdded.next(fileGroupName);
-                    this.notificationService.success(
-                        "Create file group",
-                        `${lastData.actual} files were successfully uploaded to the file group`,
-                    );
+                    if (lastData.actual > 0) {
+                        task.progress.next(100);
+                        const fileGroupName = this.fileGroupService.addFileGroupPrefix(formData.name);
+                        this.storageContainerService.onContainerAdded.next(fileGroupName);
+                        this.notificationService.success(
+                            "Create file group",
+                            `${lastData.actual} files were successfully uploaded to the file group`,
+                        );
+                    }
                 });
             }).share();
 

--- a/app/services/ncj-file-group.service.ts
+++ b/app/services/ncj-file-group.service.ts
@@ -39,7 +39,7 @@ export class NcjFileGroupService {
             fileOrFolderPath,
             { ...options, recursive: includeSubDirectories },
         ]).catch((error) => {
-            return Observable.throw(ServerError.fromPython(error));
+            return Observable.throw(error);
         });
 
         return observable;

--- a/app/services/ncj-file-group.service.ts
+++ b/app/services/ncj-file-group.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from "@angular/core";
-import { ServerError } from "@batch-flask/core";
 import { Observable } from "rxjs";
 
 import { BlobContainer } from "app/models";

--- a/python/controllers/create_file_group_controller.py
+++ b/python/controllers/create_file_group_controller.py
@@ -102,11 +102,10 @@ async def upload_files(
                 progress_callback=__uploadCallback)
 
         except ValueError as valueError:
-            logging.error("Failed to upload files to file group.", str(valueError))
+            logging.error("Failed to upload files to file group. %s", str(valueError))
             raise error.JsonRpcError(
                 code=JsonRpcErrorCodes.BATCH_CLIENT_ERROR,
-                message="Failed to upload files to file group",
-                data=str(valueError))
+                message=str(valueError))
 
     return dict(uploaded=uploaded_files, total=total_files)
 

--- a/python/jsonrpc/error.py
+++ b/python/jsonrpc/error.py
@@ -25,11 +25,11 @@ class JsonRpcError(BaseException):
         Class representing a JSON rpc error
     """
 
-    def __init__(self, code: str, message: str, data: object):
+    def __init__(self, code: str, message: str, data: object = None):
         super().__init__()
         self.code = code
         self.message = message
-        self.data = data
+        self.data = data or []
 
     def to_json(self):
         return json.dumps({

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 websockets==3.3
 pylint==1.6.5
-azure-batch-extensions==1.1.1
+azure-batch-extensions==1.1.2
 pyinstaller==3.3.1
 azure-batch==4.1.1

--- a/python/server/app.py
+++ b/python/server/app.py
@@ -65,7 +65,7 @@ class BatchLabsApp:
                     'paramDescription': e.parameter_description,
                 })
             except TypeError as e:
-                logging.error("Failed to call procedure %s, error was thrown %s", name, str(valueError))
+                logging.error("Failed to call procedure %s, error was thrown %s", name, str(e))
                 print(traceback.format_exc())
                 raise JsonRpcInvalidParamsError(str(e), e.args)
         else:

--- a/src/@batch-flask/ui/background-task/background-task-tracker-item.html
+++ b/src/@batch-flask/ui/background-task/background-task-tracker-item.html
@@ -1,8 +1,0 @@
-<div class="status-icon">
-    <div *ngIf="!(task.done | async)">
-        <mat-progress-spinner [diameter]="18" [strokeWidth]="3" mode="indeterminate" color="primary" *ngIf="(task.progress | async) === -1"></mat-progress-spinner>
-        <mat-progress-spinner [diameter]="18" [strokeWidth]="3" mode="determinate" [value]="task.progress | async" *ngIf="(task.progress | async) !== -1"></mat-progress-spinner>
-    </div>
-    <i class="fa fa-check" *ngIf="task.done | async"></i>
-</div>
-<span class="name">{{task.name | async}}</span>

--- a/src/@batch-flask/ui/background-task/background-task-tracker-item/background-task-tracker-item.component.ts
+++ b/src/@batch-flask/ui/background-task/background-task-tracker-item/background-task-tracker-item.component.ts
@@ -1,0 +1,54 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnChanges, OnDestroy } from "@angular/core";
+import { Subscription } from "rxjs";
+import { BackgroundTask } from "../background-task.model";
+
+@Component({
+    selector: "bl-background-task-tracker-item",
+    templateUrl: "background-task-tracker-item.html",
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class BackgroundTaskTrackerItemComponent implements OnChanges, OnDestroy {
+    @Input() public task: BackgroundTask;
+    public progress: number;
+    public done: boolean;
+    public name: string;
+
+    private _subs: Subscription[] = [];
+    constructor(private changeDetector: ChangeDetectorRef) {
+
+    }
+
+    public ngOnChanges(changes) {
+        if (changes.task) {
+            this._listenForProgress();
+        }
+    }
+
+    public ngOnDestroy() {
+        this._clearSubs();
+    }
+
+    private _listenForProgress() {
+        this._clearSubs();
+
+        if (this.task) { return; }
+
+        this._subs.push(this.task.progress.subscribe((progress) => {
+            this.progress = progress;
+            this.changeDetector.markForCheck();
+        }));
+        this._subs.push(this.task.done.subscribe((done) => {
+            this.done = done;
+            this.changeDetector.markForCheck();
+        }));
+        this._subs.push(this.task.name.subscribe((name) => {
+            this.name = name;
+            this.changeDetector.markForCheck();
+        }));
+    }
+
+    private _clearSubs() {
+        this._subs.forEach(x => x.unsubscribe());
+        this._subs = [];
+    }
+}

--- a/src/@batch-flask/ui/background-task/background-task-tracker-item/background-task-tracker-item.component.ts
+++ b/src/@batch-flask/ui/background-task/background-task-tracker-item/background-task-tracker-item.component.ts
@@ -15,7 +15,6 @@ export class BackgroundTaskTrackerItemComponent implements OnChanges, OnDestroy 
 
     private _subs: Subscription[] = [];
     constructor(private changeDetector: ChangeDetectorRef) {
-
     }
 
     public ngOnChanges(changes) {
@@ -31,7 +30,7 @@ export class BackgroundTaskTrackerItemComponent implements OnChanges, OnDestroy 
     private _listenForProgress() {
         this._clearSubs();
 
-        if (this.task) { return; }
+        if (!this.task) { return; }
 
         this._subs.push(this.task.progress.subscribe((progress) => {
             this.progress = progress;

--- a/src/@batch-flask/ui/background-task/background-task-tracker-item/background-task-tracker-item.html
+++ b/src/@batch-flask/ui/background-task/background-task-tracker-item/background-task-tracker-item.html
@@ -1,5 +1,5 @@
 <div class="status-icon">
-    <div *ngIf="done">
+    <div *ngIf="!done">
         <mat-progress-spinner [diameter]="18" [strokeWidth]="3" mode="indeterminate" color="primary" *ngIf="progress === -1"></mat-progress-spinner>
         <mat-progress-spinner [diameter]="18" [strokeWidth]="3" mode="determinate" [value]="progress" *ngIf="progress !== -1"></mat-progress-spinner>
     </div>

--- a/src/@batch-flask/ui/background-task/background-task-tracker-item/background-task-tracker-item.html
+++ b/src/@batch-flask/ui/background-task/background-task-tracker-item/background-task-tracker-item.html
@@ -1,0 +1,8 @@
+<div class="status-icon">
+    <div *ngIf="done">
+        <mat-progress-spinner [diameter]="18" [strokeWidth]="3" mode="indeterminate" color="primary" *ngIf="progress === -1"></mat-progress-spinner>
+        <mat-progress-spinner [diameter]="18" [strokeWidth]="3" mode="determinate" [value]="progress" *ngIf="progress !== -1"></mat-progress-spinner>
+    </div>
+    <i class="fa fa-check" *ngIf="done"></i>
+</div>
+<span class="name">{{name}}</span>

--- a/src/@batch-flask/ui/background-task/background-task-tracker-item/index.ts
+++ b/src/@batch-flask/ui/background-task/background-task-tracker-item/index.ts
@@ -1,0 +1,1 @@
+export * from "./background-task-tracker-item.component";

--- a/src/@batch-flask/ui/background-task/background-task-tracker.component.ts
+++ b/src/@batch-flask/ui/background-task/background-task-tracker.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnDestroy } from "@angular/core";
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy } from "@angular/core";
 import { List } from "immutable";
 import { Subscription } from "rxjs";
 

--- a/src/@batch-flask/ui/background-task/background-task-tracker.component.ts
+++ b/src/@batch-flask/ui/background-task/background-task-tracker.component.ts
@@ -1,5 +1,6 @@
-import { Component, Input } from "@angular/core";
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnDestroy } from "@angular/core";
 import { List } from "immutable";
+import { Subscription } from "rxjs";
 
 import { BackgroundTask } from "./background-task.model";
 import { BackgroundTaskService } from "./background-task.service";
@@ -9,8 +10,9 @@ import "./background-task-tracker.scss";
 @Component({
     selector: "bl-background-task-tracker",
     templateUrl: "background-task-tracker.html",
+    changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class BackgroundTaskTrackerComponent {
+export class BackgroundTaskTrackerComponent implements OnDestroy {
 
     public currentTask: BackgroundTask;
     public otherTasks: List<BackgroundTask>;
@@ -21,34 +23,34 @@ export class BackgroundTaskTrackerComponent {
     public showFlash = false;
 
     private _lastTaskCount = 0;
+    private _sub: Subscription;
 
-    constructor(public taskManager: BackgroundTaskService) {
-        taskManager.runningTasks.subscribe((tasks) => {
+    constructor(public taskManager: BackgroundTaskService, private changeDetector: ChangeDetectorRef) {
+        this._sub = taskManager.runningTasks.subscribe((tasks) => {
             this.currentTask = tasks.first();
             this.otherTasks = tasks.shift();
             if (this._lastTaskCount < tasks.size) {
                 this.flash();
             }
             this._lastTaskCount = tasks.size;
+            this.changeDetector.markForCheck();
         });
+    }
+
+    public ngOnDestroy() {
+        this._sub.unsubscribe();
     }
 
     public flash() {
         this.showFlash = true;
+        this.changeDetector.markForCheck();
         setTimeout(() => {
             this.showFlash = false;
+            this.changeDetector.markForCheck();
         }, 1000);
     }
 
     public trackByFn(index, task: BackgroundTask) {
         return task.id;
     }
-}
-
-@Component({
-    selector: "bl-background-task-tracker-item",
-    templateUrl: "background-task-tracker-item.html",
-})
-export class BackgroundTaskTrackerItemComponent {
-    @Input() public task: BackgroundTask;
 }

--- a/src/@batch-flask/ui/background-task/background-task.module.ts
+++ b/src/@batch-flask/ui/background-task/background-task.module.ts
@@ -5,8 +5,9 @@ import { MaterialModule } from "@batch-flask/core";
 
 import { DropdownModule } from "../dropdown";
 import { NotificationModule } from "../notifications";
+import { BackgroundTaskTrackerItemComponent } from "./background-task-tracker-item";
 import {
-    BackgroundTaskTrackerComponent, BackgroundTaskTrackerItemComponent,
+    BackgroundTaskTrackerComponent,
 } from "./background-task-tracker.component";
 import { BackgroundTaskService } from "./background-task.service";
 

--- a/src/client/startup.ts
+++ b/src/client/startup.ts
@@ -45,7 +45,7 @@ async function startApplication(batchLabsApp: BatchLabsApplication) {
     // Uncomment to view why windows don't show up.
     batchLabsApp.init().then(() => {
         batchLabsApp.start();
-        batchLabsApp.debugCrash();
+        // batchLabsApp.debugCrash();
     });
 }
 

--- a/src/client/startup.ts
+++ b/src/client/startup.ts
@@ -45,7 +45,7 @@ async function startApplication(batchLabsApp: BatchLabsApplication) {
     // Uncomment to view why windows don't show up.
     batchLabsApp.init().then(() => {
         batchLabsApp.start();
-        // batchLabsApp.debugCrash();
+        batchLabsApp.debugCrash();
     });
 }
 


### PR DESCRIPTION
fix #1355 

Also refactor background task tracker to use `OnPush` for perf
![image](https://user-images.githubusercontent.com/1031227/40377881-d87b8e8e-5da6-11e8-9659-f76279f1270a.png)
