### PR TITLE
Feature: Call rest api directly for resize as there is an issue with duration on mac

### DIFF
--- a/app/app.module.ts
+++ b/app/app.module.ts
@@ -36,6 +36,7 @@ import { MaterialModule } from "@batch-flask/core";
 import { CommonModule } from "app/components/common";
 import { LayoutModule } from "app/components/layout";
 import { MiscModule } from "app/components/misc";
+import { AzureBatchHttpService } from "app/services/azure-batch/core";
 import { PollService } from "app/services/core";
 import { AADApplicationService, ServicePrincipalService } from "app/services/ms-graph";
 import { AADGraphHttpService, MsGraphHttpService } from "app/services/ms-graph/core";
@@ -130,6 +131,7 @@ const graphApiServices = [AADApplicationService, AADGraphHttpService, MsGraphHtt
         AppInsightsQueryService,
         ApplicationService,
         AutoscaleFormulaService,
+        AzureBatchHttpService,
         AzureHttpService,
         ArmHttpService,
         AuthorizationHttpService,

--- a/app/services/azure-batch/core/batch-http.service.ts
+++ b/app/services/azure-batch/core/batch-http.service.ts
@@ -41,7 +41,7 @@ export class AzureBatchHttpService extends HttpService {
                             options)
                             .retryWhen(attempts => this.retryWhen(attempts))
                             .catch((error) => {
-                                const err = ServerError.fromBatch(error);
+                                const err = ServerError.fromBatchHttp(error);
                                 return Observable.throw(err);
                             });
                     });
@@ -57,7 +57,8 @@ export class AzureBatchHttpService extends HttpService {
             options.params = options.params.set("api-version", Constants.ApiVersion.batchService);
         }
 
-        options.headers = (options.headers as any).set("Content-Type", "application/json; odata=minimalmetadata; charset=utf-8");
+        options.headers = (options.headers as any)
+            .set("Content-Type", "application/json; odata=minimalmetadata; charset=utf-8");
 
         return options;
     }

--- a/app/services/azure-batch/core/batch-http.service.ts
+++ b/app/services/azure-batch/core/batch-http.service.ts
@@ -1,0 +1,72 @@
+import { Location } from "@angular/common";
+import { HttpClient, HttpParams } from "@angular/common/http";
+import { Injectable } from "@angular/core";
+import { HttpRequestOptions, HttpService, ServerError } from "@batch-flask/core";
+import { UrlUtils } from "@batch-flask/utils";
+import { AccountResource } from "app/models";
+import { AccountService } from "app/services/account.service";
+import { AdalService } from "app/services/adal";
+import { BatchLabsService } from "app/services/batch-labs.service";
+import { AADUser } from "client/core/aad/adal/aad-user";
+import { Constants } from "common";
+import { Observable } from "rxjs";
+
+@Injectable()
+export class AzureBatchHttpService extends HttpService {
+    public get serviceUrl() {
+        return this.batchLabs.azureEnvironment.batchUrl;
+    }
+
+    private _currentUser: AADUser;
+    constructor(
+        private http: HttpClient,
+        private adal: AdalService,
+        private accountService: AccountService,
+        private batchLabs: BatchLabsService) {
+        super();
+        this.adal.currentUser.subscribe(x => this._currentUser = x);
+    }
+
+    public request<T = any>(method: string, uri: string, options: any): Observable<T> {
+        return this.accountService.currentAccount.take(1)
+            .flatMap((account) => {
+                const tenantId = account.subscription.tenantId;
+                return this.adal.accessTokenData(tenantId, this.serviceUrl)
+                    .flatMap((accessToken) => {
+                        options = this.addAuthorizationHeader(options, accessToken);
+                        options = this._addApiVersion(options);
+                        return this.http.request<T>(
+                            method,
+                            this._computeUrl(uri, account),
+                            options)
+                            .retryWhen(attempts => this.retryWhen(attempts))
+                            .catch((error) => {
+                                const err = ServerError.fromBatch(error);
+                                return Observable.throw(err);
+                            });
+                    });
+            }).shareReplay(1);
+    }
+
+    private _addApiVersion(options: HttpRequestOptions): HttpRequestOptions {
+        if (!(options.params instanceof HttpParams)) {
+            options.params = new HttpParams(options.params);
+        }
+
+        if (!options.params.get("api-version")) {
+            options.params = options.params.set("api-version", Constants.ApiVersion.batchService);
+        }
+
+        options.headers = (options.headers as any).set("Content-Type", "application/json; odata=minimalmetadata; charset=utf-8");
+
+        return options;
+    }
+
+    private _computeUrl(uri: string, account: AccountResource) {
+        if (UrlUtils.isHttpUrl(uri)) {
+            return uri;
+        } else {
+            return Location.joinWithSlash(`https://${account.properties.accountEndpoint}`, uri);
+        }
+    }
+}

--- a/app/services/azure-batch/core/index.ts
+++ b/app/services/azure-batch/core/index.ts
@@ -1,0 +1,1 @@
+export * from "./batch-http.service";

--- a/app/services/batch-api/poolProxy.ts
+++ b/app/services/batch-api/poolProxy.ts
@@ -36,17 +36,6 @@ export class PoolProxy {
         return this.client.pool.deleteMethod(poolId, wrapOptions(options));
     }
 
-    /**
-     * Resizes the specified pool to the target number of nodes
-     * http://azure.github.io/azure-sdk-for-node/azure-batch/latest/Pool.html#resize
-     * @param poolId: The id of the pool to resize.
-     * @param targetDedicated: The desired number of nodes in the pool
-     * @param options: Optional Parameters.
-     */
-    public resize(poolId: string, target: any, options?: any): Promise<any> {
-        return this.client.pool.resize(poolId, target, wrapOptions(options));
-    }
-
     public patch(poolId: string, attributes: any, options?: any): Promise<any> {
         return this.client.pool.patch(poolId, attributes, wrapOptions(options));
     }
@@ -63,21 +52,5 @@ export class PoolProxy {
      */
     public add(pool: any, options?: any): Promise<any> {
         return this.client.pool.add(pool, wrapOptions(options));
-    }
-
-    public enableAutoScale(
-        poolId: string,
-        attributes: BatchServiceModels.PoolEnableAutoScaleParameter,
-        options?: any): Promise<any> {
-
-        return this.client.pool.enableAutoScale(poolId, attributes, wrapOptions(options));
-    }
-
-    public disableAutoScale(poolId: string, options?: any): Promise<any> {
-        return this.client.pool.disableAutoScale(poolId, wrapOptions(options));
-    }
-
-    public evaluateAutoScale(poolId: string, formula: string, options?: any): Promise<any> {
-        return this.client.pool.evaluateAutoScale(poolId, { autoScaleFormula: formula }, wrapOptions(options));
     }
 }

--- a/app/services/pool.service.ts
+++ b/app/services/pool.service.ts
@@ -6,6 +6,7 @@ import { PoolCreateDto, PoolEnableAutoScaleDto, PoolPatchDto, PoolResizeDto } fr
 import { BatchEntityGetter, EntityView, ListView } from "app/services/core";
 import { Constants, ModelUtils, log } from "app/utils";
 import { List } from "immutable";
+import { AzureBatchHttpService } from "./azure-batch/core";
 import { BatchClientService } from "./batch-client.service";
 import { BatchListGetter, ContinuationToken, DataCache, ListOptionsAttributes } from "./core";
 import { ServiceBase } from "./service-base";
@@ -30,7 +31,7 @@ export class PoolService extends ServiceBase {
     private _getter: BatchEntityGetter<Pool, PoolParams>;
     private _listGetter: BatchListGetter<Pool, PoolListParams>;
 
-    constructor(batchService: BatchClientService) {
+    constructor(batchService: BatchClientService, private http: AzureBatchHttpService) {
         super(batchService);
 
         this._getter = new BatchEntityGetter(Pool, this.batchService, {
@@ -128,9 +129,11 @@ export class PoolService extends ServiceBase {
     }
 
     public resize(poolId: string, target: PoolResizeDto, options: any = {}) {
-        return this.callBatchClient((client) => client.pool.resize(poolId, target.toJS(), options), (error) => {
-            log.error("Error resizing pool: " + poolId, Object.assign({}, error));
-        });
+        // return this.callBatchClient((client) => client.pool.resize(poolId, target.toJS(), options), (error) => {
+        //     log.error("Error resizing pool: " + poolId, Object.assign({}, error));
+        // });
+
+        return this.http.post(`/pools/${poolId}/resize`, target.toJS());
     }
 
     public patch(poolId: string, attributes: PoolPatchDto, options: any = {}) {

--- a/app/services/pool.service.ts
+++ b/app/services/pool.service.ts
@@ -129,10 +129,6 @@ export class PoolService extends ServiceBase {
     }
 
     public resize(poolId: string, target: PoolResizeDto, options: any = {}) {
-        // return this.callBatchClient((client) => client.pool.resize(poolId, target.toJS(), options), (error) => {
-        //     log.error("Error resizing pool: " + poolId, Object.assign({}, error));
-        // });
-
         return this.http.post(`/pools/${poolId}/resize`, target.toJS());
     }
 
@@ -157,20 +153,16 @@ export class PoolService extends ServiceBase {
     }
 
     public enableAutoScale(poolId: string, autoscaleParams: PoolEnableAutoScaleDto) {
-        return this.callBatchClient((client) => client.pool.enableAutoScale(poolId, autoscaleParams), (error) => {
-            log.error("Error enabling autoscale for pool: " + poolId, error);
-        });
+        return this.http.post(`/pools/${poolId}/enableautoscale`, autoscaleParams);
     }
 
-    public evaluateAutoScale(poolId: string, options: any = {}) {
-        return this.callBatchClient((client) => client.pool.evaluateAutoScale(poolId, options), (error) => {
-            log.error("Error resizing pool: " + poolId, Object.assign({}, error));
+    public evaluateAutoScale(poolId: string, formula: string) {
+        return this.http.post(`/pools/${poolId}/evaluateautoscale`, {
+            autoScaleFormula: formula,
         });
     }
 
     public disableAutoScale(poolId: string) {
-        return this.callBatchClient((client) => client.pool.disableAutoScale(poolId), (error) => {
-            log.error("Error disabling autoscale for pool: " + poolId, error);
-        });
+        return this.http.post(`/pools/${poolId}/disableautoscale`);
     }
 }

--- a/src/@batch-flask/core/http-base.ts
+++ b/src/@batch-flask/core/http-base.ts
@@ -49,7 +49,7 @@ export abstract class HttpService {
 
     public post<T>(uri: string, body: any, options: HttpRequestOptions<"events">): Observable<HttpEvent<T>>;
     public post<T>(uri: string, body: any, options: HttpRequestOptions<"response">): Observable<HttpResponse<T>>;
-    public post<T>(uri: string, body: any, options?: HttpRequestOptions): Observable<T>;
+    public post<T>(uri: string, body?: any, options?: HttpRequestOptions): Observable<T>;
     public post(uri: string, body?: any, options?: any) {
         return this.request("post", uri, { body, ...options });
     }

--- a/src/@batch-flask/core/server-error/server-error.ts
+++ b/src/@batch-flask/core/server-error/server-error.ts
@@ -71,7 +71,7 @@ export class ServerError {
         return new ServerError({
             status: error.statusCode,
             code: error.code,
-            details: error.body && error.body.values,
+            details: error.values,
             message: message || error.message as string,
             requestId,
             timestamp,

--- a/src/@batch-flask/core/server-error/server-error.ts
+++ b/src/@batch-flask/core/server-error/server-error.ts
@@ -62,7 +62,25 @@ function parseMessage(fullMessage: string) {
  * All their error format needs to be converted to this one so it can then be consumed easily
  */
 export class ServerError {
+    public static fromBatchHttp(response: HttpErrorResponse) {
+        const error = response.error;
+        const { message, requestId, timestamp } = parseMessage(error.message && error.message.value);
+
+        // when the error message returned is not of type ErrorMessage, it will more often
+        // than not be a string.
+        return new ServerError({
+            status: error.statusCode,
+            code: error.code,
+            details: error.body && error.body.values,
+            message: message || error.message as string,
+            requestId,
+            timestamp,
+            original: error,
+        });
+    }
+
     public static fromBatch(error: BatchError) {
+        console.log("Error", error);
         const { message, requestId, timestamp } = parseMessage(error.message && error.message.value);
 
         // when the error message returned is not of type ErrorMessage, it will more often

--- a/src/@batch-flask/core/server-error/server-error.ts
+++ b/src/@batch-flask/core/server-error/server-error.ts
@@ -80,7 +80,6 @@ export class ServerError {
     }
 
     public static fromBatch(error: BatchError) {
-        console.log("Error", error);
         const { message, requestId, timestamp } = parseMessage(error.message && error.message.value);
 
         // when the error message returned is not of type ErrorMessage, it will more often

--- a/src/common/constants/constants.ts
+++ b/src/common/constants/constants.ts
@@ -114,6 +114,7 @@ export const ApiVersion = {
     monitor: "2017-05-01-preview",
     network: "2017-10-01",
     classicNetwork: "2015-12-01",
+    batchService: "2017-09-01.6.0",
 };
 
 export const ExternalLinks = {


### PR DESCRIPTION
fix #1413 
This set the foundation to call the rest api directly without the sdk, which means we could potentially get rid of it and save in bundle size