### PR TITLE
Fix: App insights docs having wrong environment variables names

### DIFF
--- a/app/components/pool/graphs/performance-graph/enable-app-insights-doc/enable-app-insights-doc.html
+++ b/app/components/pool/graphs/performance-graph/enable-app-insights-doc/enable-app-insights-doc.html
@@ -7,8 +7,8 @@
 
 <h4>Quick Steps</h4>
 <ol>
-    <li>1. Add `APP_INSIGHTS_KEY` environment variable in the start task(App insights instrumentation key)</li>
-    <li>2. Add `APP_INSIGHTS_INSTRUMENTATION_KEY` environment variable in the start task(App insights application ID)</li>
+    <li>1. Add `APP_INSIGHTS_INSTRUMENTATION_KEY` environment variable in the start task(App insights instrumentation key)</li>
+    <li>2. Add `APP_INSIGHTS_APP_ID` environment variable in the start task(App insights application ID)</li>
     <li>3. Add os specific one liner in your start task see
         <bl-clickable (do)="openDoc('#ubuntu')">doc</bl-clickable>
     </li>


### PR DESCRIPTION
fix #1443 